### PR TITLE
Feature/use agent instance map

### DIFF
--- a/src/simularium/VisAgent.ts
+++ b/src/simularium/VisAgent.ts
@@ -364,7 +364,6 @@ export default class VisAgent {
     public hideAndDeactivate(): void {
         this.hide();
         this.active = false;
-        this.id = NO_AGENT;
     }
 
     public hasDrawablePDB(): boolean {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -934,6 +934,10 @@ class VisGeometry {
         });
     }
 
+    public clearColorMapping(): void {
+        this.idColorMapping.clear();
+    }
+
     private getColorIndexForTypeId(typeId: number): number {
         const index = this.idColorMapping.get(typeId);
         if (index === undefined) {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -114,7 +114,6 @@ class VisGeometry {
     public meshLoadAttempted: Map<string, boolean>;
     public pdbLoadAttempted: Map<string, boolean>;
     public scaleMapping: Map<number, number>;
-    //public geomCount: number;
     public followObjectId: number;
     public visAgents: VisAgent[];
     public visAgentInstances: Map<number, VisAgent>;
@@ -175,7 +174,6 @@ class VisGeometry {
         this.pdbLoadAttempted = new Map<string, boolean>();
         this.scaleMapping = new Map<number, number>();
         this.idColorMapping = new Map<number, number>();
-        //this.geomCount = MAX_MESHES;
         this.followObjectId = NO_AGENT;
         this.visAgents = [];
         this.visAgentInstances = new Map<number, VisAgent>();
@@ -1342,8 +1340,6 @@ class VisGeometry {
     public updateScene(agents: AgentData[]): void {
         this.currentSceneAgents = agents;
 
-        let numUpdatesToFiber = 0;
-        let numUpdatesToMesh = 0;
         let dx = 0,
             dy = 0,
             dz = 0;
@@ -1355,7 +1351,7 @@ class VisGeometry {
             this.fiberEndcaps.beginUpdate(agents.length);
         }
 
-        agents.forEach((agentData, i) => {
+        agents.forEach((agentData) => {
             const visType = agentData["vis-type"];
             const instanceId = agentData.instanceId;
             const typeId = agentData.type;

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1339,6 +1339,8 @@ class VisGeometry {
     public updateScene(agents: AgentData[]): void {
         this.currentSceneAgents = agents;
 
+        let numUpdatesToFiber = 0;
+        let numUpdatesToMesh = 0;
         let dx = 0,
             dy = 0,
             dz = 0;
@@ -1399,6 +1401,7 @@ class VisGeometry {
                     typeId !== lastTypeId ||
                     visType !== visAgent.visType
                 ) {
+                    numUpdatesToMesh += 1;
                     const meshGeom = this.getGeomFromId(typeId);
                     visAgent.visType = visType;
                     if (meshGeom) {
@@ -1505,6 +1508,7 @@ class VisGeometry {
                 }
                 // did the agent type change since the last sim time?
                 if (wasHidden || typeId !== lastTypeId) {
+                    numUpdatesToFiber += 1;
                     visAgent.mesh.userData = { id: visAgent.id };
                     // for fibers we currently only check the color
                     visAgent.setColor(
@@ -1560,6 +1564,7 @@ class VisGeometry {
         if (USE_INSTANCE_ENDCAPS) {
             this.fiberEndcaps.endUpdate();
         }
+        console.log(numUpdatesToMesh, numUpdatesToFiber);
     }
 
     public animateCamera(): void {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1913,10 +1913,14 @@ class VisGeometry {
 
     public clearForNewTrajectory(): void {
         this.resetMapping();
+        this.idColorMapping.clear();
+
         // remove current scene agents.
         this.visAgentInstances.clear();
         this.visAgents = [];
         this.currentSceneAgents = [];
+
+        this.dehighlight();
     }
 
     private cancelAllAsyncProcessing(): void {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1884,18 +1884,6 @@ class VisGeometry {
         }
     }
 
-    public clear(): void {
-        // just hide and deactivate all agents and paths
-        const nMeshes = this.visAgents.length;
-        for (let i = 0; i < MAX_MESHES && i < nMeshes; i += 1) {
-            const visAgent = this.visAgents[i];
-            // hide the path if we're hiding the agent. should we remove the path here?
-            this.showPathForAgent(visAgent.id, false);
-            visAgent.hideAndDeactivate();
-            visAgent.id = NO_AGENT;
-        }
-    }
-
     public clearForNewTrajectory(): void {
         this.resetMapping();
 

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -966,17 +966,6 @@ class VisGeometry {
         );
     }
 
-    public createMeshes(): void {
-        //this.geomCount = MAX_MESHES;
-        // multipass render:
-        // draw moleculebuffer into several render targets to store depth, normals, colors
-        // draw quad to composite the buffers into final frame
-        // create placeholder agents
-        // for (let i = 0; i < this.geomCount; i += 1) {
-        //     this.visAgents[i] = new VisAgent(`Agent_${i}`);
-        // }
-    }
-
     /**
      *   Data Management
      */

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1393,6 +1393,9 @@ class VisGeometry {
                 return;
             }
 
+            const isHighlighted = this.highlightedIds.includes(visAgent.typeId);
+            visAgent.setHighlighted(isHighlighted);
+
             // if not fiber...
             if (visType === VisTypes.ID_VIS_TYPE_DEFAULT) {
                 // did the agent type change since the last sim time?
@@ -1556,8 +1559,6 @@ class VisGeometry {
                     );
                 }
             }
-            const isHighlighted = this.highlightedIds.includes(visAgent.typeId);
-            visAgent.setHighlighted(isHighlighted);
         });
 
         this.hideUnusedAgents(agents.length);

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -114,7 +114,7 @@ class VisGeometry {
     public meshLoadAttempted: Map<string, boolean>;
     public pdbLoadAttempted: Map<string, boolean>;
     public scaleMapping: Map<number, number>;
-    public geomCount: number;
+    //public geomCount: number;
     public followObjectId: number;
     public visAgents: VisAgent[];
     public visAgentInstances: Map<number, VisAgent>;
@@ -175,7 +175,7 @@ class VisGeometry {
         this.pdbLoadAttempted = new Map<string, boolean>();
         this.scaleMapping = new Map<number, number>();
         this.idColorMapping = new Map<number, number>();
-        this.geomCount = MAX_MESHES;
+        //this.geomCount = MAX_MESHES;
         this.followObjectId = NO_AGENT;
         this.visAgents = [];
         this.visAgentInstances = new Map<number, VisAgent>();
@@ -959,16 +959,14 @@ class VisGeometry {
     }
 
     public createMeshes(): void {
-        this.geomCount = MAX_MESHES;
-
+        //this.geomCount = MAX_MESHES;
         // multipass render:
         // draw moleculebuffer into several render targets to store depth, normals, colors
         // draw quad to composite the buffers into final frame
-
         // create placeholder agents
-        for (let i = 0; i < this.geomCount; i += 1) {
-            this.visAgents[i] = new VisAgent(`Agent_${i}`);
-        }
+        // for (let i = 0; i < this.geomCount; i += 1) {
+        //     this.visAgents[i] = new VisAgent(`Agent_${i}`);
+        // }
     }
 
     /**
@@ -1333,6 +1331,14 @@ class VisGeometry {
         return 1;
     }
 
+    private createAgent(): VisAgent {
+        // TODO limit the number
+        const i = this.visAgents.length;
+        const agent = new VisAgent(`Agent_${i}`);
+        this.visAgents.push(agent);
+        return agent;
+    }
+
     /**
      *   Update Scene
      **/
@@ -1363,22 +1369,25 @@ class VisGeometry {
             lasty = agentData.y;
             lastz = agentData.z;
 
+            let visAgent = this.visAgentInstances.get(instanceId);
+
             const path = this.findPathForAgent(instanceId);
             if (path) {
                 // look up last agent with this instanceId.
-                const lastInstance = this.visAgentInstances.get(instanceId);
-                if (lastInstance && lastInstance.mesh) {
-                    lastx = lastInstance.mesh.position.x;
-                    lasty = lastInstance.mesh.position.y;
-                    lastz = lastInstance.mesh.position.z;
+                if (visAgent && visAgent.mesh) {
+                    lastx = visAgent.mesh.position.x;
+                    lasty = visAgent.mesh.position.y;
+                    lastz = visAgent.mesh.position.z;
                 }
             }
 
-            const visAgent = this.visAgents[i];
+            if (!visAgent) {
+                visAgent = this.createAgent();
+                this.visAgentInstances.set(instanceId, visAgent);
+            }
+
             visAgent.id = instanceId;
             visAgent.mesh.userData = { id: instanceId };
-            // note there may still be another agent later in the list with the same id, until it gets reset
-            this.visAgentInstances.set(instanceId, visAgent);
 
             const lastTypeId = visAgent.typeId;
 
@@ -1390,6 +1399,7 @@ class VisGeometry {
             visAgent.setHidden(isHidden);
             if (visAgent.hidden) {
                 visAgent.hide();
+                console.log("HIDING");
                 return;
             }
 
@@ -1900,6 +1910,7 @@ class VisGeometry {
         this.resetMapping();
         // remove current scene agents.
         this.visAgentInstances.clear();
+        this.visAgents = [];
         this.currentSceneAgents = [];
     }
 

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -955,7 +955,6 @@ class VisGeometry {
     public setColorForIds(ids: number[], colorId: number): void {
         ids.forEach((id) => {
             this.idColorMapping.set(id, colorId);
-            //console.log("Set Color for ID: " + id);
         });
     }
 
@@ -1408,7 +1407,6 @@ class VisGeometry {
             visAgent.setHidden(isHidden);
             if (visAgent.hidden) {
                 visAgent.hide();
-                console.log("HIDING");
                 return;
             }
 
@@ -1423,7 +1421,6 @@ class VisGeometry {
                     typeId !== lastTypeId ||
                     visType !== visAgent.visType
                 ) {
-                    numUpdatesToMesh += 1;
                     const meshGeom = this.getGeomFromId(typeId);
                     visAgent.visType = visType;
                     if (meshGeom) {
@@ -1530,7 +1527,6 @@ class VisGeometry {
                 }
                 // did the agent type change since the last sim time?
                 if (wasHidden || typeId !== lastTypeId) {
-                    numUpdatesToFiber += 1;
                     visAgent.mesh.userData = { id: visAgent.id };
                     // for fibers we currently only check the color
                     visAgent.setColor(
@@ -1584,7 +1580,6 @@ class VisGeometry {
         if (USE_INSTANCE_ENDCAPS) {
             this.fiberEndcaps.endUpdate();
         }
-        console.log(numUpdatesToMesh, numUpdatesToFiber);
     }
 
     public animateCamera(): void {
@@ -1917,7 +1912,6 @@ class VisGeometry {
 
     public clearForNewTrajectory(): void {
         this.resetMapping();
-        this.idColorMapping.clear();
 
         // remove current scene agents.
         this.visAgentInstances.clear();

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -935,7 +935,11 @@ class VisGeometry {
     }
 
     private getColorIndexForTypeId(typeId: number): number {
-        const index = this.idColorMapping[typeId];
+        const index = this.idColorMapping.get(typeId);
+        if (index === undefined) {
+            console.log("getColorIndexForTypeId could not find " + typeId);
+            return 0;
+        }
         return index % (this.colorsData.length / 4);
     }
 
@@ -946,7 +950,8 @@ class VisGeometry {
 
     public setColorForIds(ids: number[], colorId: number): void {
         ids.forEach((id) => {
-            this.idColorMapping[id] = colorId;
+            this.idColorMapping.set(id, colorId);
+            //console.log("Set Color for ID: " + id);
         });
     }
 

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -145,7 +145,6 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         this.visGeometry = new VisGeometry(loggerLevel);
         this.visGeometry.setupScene();
         this.visGeometry.createMaterials(colors);
-        this.visGeometry.createMeshes();
         this.vdomRef = React.createRef();
         this.lastRenderTime = Date.now();
         this.startTime = Date.now();

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -224,6 +224,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             }
             onTrajectoryFileInfoChanged(msg);
 
+            this.visGeometry.clearColorMapping();
             const uiDisplayData = this.selectionInterface.getUIDisplayData();
             let colorIndex = 0;
             uiDisplayData.forEach((entry) => {
@@ -448,7 +449,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         }
     };
 
-    public handleMouseMove = (e: Event):void => {
+    public handleMouseMove = (e: Event): void => {
         const event = e as MouseEvent;
         if (!this.vdomRef.current) {
             return;
@@ -462,7 +463,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         } else {
             this.vdomRef.current.style.cursor = "default";
         }
-    }
+    };
 
     public addEventHandlersToCanvas(): void {
         forOwn(this.handlers, (handler, eventName) =>


### PR DESCRIPTION
This change set is an optimization primarily. 

Previously the main update loop for rendering, updateScene in the VisGeometry module, was looking up agent indices in a flat array of agents, in the order they arrive at the client.  However, agents could arrive in shuffled order, and if the order on consecutive frames was shuffled in any way, then the result was that the internals of an agent in the array would be almost completely removed and replaced with another agent.  

For example, if the Nth agent in the list on frame 1 was a sphere with unique id X, but on frame 2 it might be a fiber with unique id Y, then the Nth agent in the flat array would have to be completely changed from sphere X to fiber Y.

The optimization is to not look up agents by index into the flat array, but to look them up by their unique id (X or Y in the above example).  The result is FAR less thrashing of agents' internals. In fact, almost none.  Memory pressure is relieved and there is a speedup in CPU time.

* I am also no longer pre-allocating agents.  They are allocated on demand dynamically now.

* There is one more change included to catch a case in which bad data causes bad color mappings.  I catch it now and log it to the console if it ever happens.

