### PR TITLE
Fix/remove endcaps

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1935,6 +1935,9 @@ class VisGeometry {
         for (let i = this.agentPDBGroup.children.length - 1; i >= 0; i--) {
             this.agentPDBGroup.remove(this.agentPDBGroup.children[i]);
         }
+        for (let i = this.instancedMeshGroup.children.length - 1; i >= 0; i--) {
+            this.instancedMeshGroup.remove(this.instancedMeshGroup.children[i]);
+        }
 
         // set all runtime meshes back to spheres.
         for (const visAgent of this.visAgentInstances.values()) {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1939,6 +1939,8 @@ class VisGeometry {
             this.instancedMeshGroup.remove(this.instancedMeshGroup.children[i]);
         }
 
+        this.fiberEndcaps.create(0);
+
         // set all runtime meshes back to spheres.
         for (const visAgent of this.visAgentInstances.values()) {
             visAgent.resetMesh();


### PR DESCRIPTION
Fixes a bug in which fiber endcaps were still visible as highlighted geometry after leaving a trajectory and returning to a fresh empty viewer.  This doesn't touch the highlighting state, but ensures that the fiber endcaps are really gone.

(Repro steps: 
In simularium-website, select endocytosis and proceed to viewer.  
then click simularium home, 
then click the "load my own data" card to return to an empty viewer.
)