### PR TITLE
reset fiber endcaps more robustly

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -1936,7 +1936,8 @@ class VisGeometry {
             this.instancedMeshGroup.remove(this.instancedMeshGroup.children[i]);
         }
 
-        this.fiberEndcaps.create(0);
+        // recreate an empty set of fiber endcaps to clear out the old ones.
+        this.constructInstancedFiberEndcaps();
 
         // set all runtime meshes back to spheres.
         for (const visAgent of this.visAgentInstances.values()) {


### PR DESCRIPTION
fiber endcaps are not really supposed to be reallocated to decrease their number.  simplest is to re-create the whole object in this scenario.
