### PR TITLE
bugfix/yellow-agents

### DIFF
--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -245,6 +245,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                         .getHexString();
                 colorIndex = colorIndex + 1;
             });
+	    this.visGeometry.finalizeIdColorMapping();
 
             onUIDisplayDataChanged(uiDisplayData);
         };


### PR DESCRIPTION
**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Check for a color mapping before rendering, return early from `updateScene(...)` if none has arrived yet. With the arraybuffer changes, the data for the first frame was processing and arriving before the trajectory file info.

We will need to increment the back-end version to completely fix this in staging and production. They array-buffer changes removed an unused net message type. The old versions of the back-end will be sending an outdated message type for trajectory file update (type 13 vs type 12).

After these changes, no more (unintended) yellow agents.

