### PR TITLE
Feature/rename TrajectoryFileInfoV2 interface as TrajectoryFileInfo

### DIFF
--- a/src/simularium/index.tsx
+++ b/src/simularium/index.tsx
@@ -5,8 +5,6 @@ export type {
     VisDataMessage,
     VisDataFrame,
     TrajectoryFileInfo,
-    TrajectoryFileInfoV1,
-    TrajectoryFileInfoV2,
     EncodedTypeMapping,
     SimulariumFileFormat,
 } from "./types";

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -83,7 +83,7 @@ export type TrajectoryFileInfoAny = TrajectoryFileInfoV1 | TrajectoryFileInfoV2;
 export type TrajectoryFileInfo = TrajectoryFileInfoV2;
 
 export interface SimulariumFileFormat {
-    trajectoryInfo: TrajectoryFileInfoAny;
+    trajectoryInfo: TrajectoryFileInfo;
     spatialData: VisDataMessage;
     plotData: CachedObservables;
 }

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -51,7 +51,7 @@ export interface EncodedTypeMapping {
 interface TrajectoryFileInfoBase {
     connId: string;
     msgType: number;
-    version: number;
+    readonly version: number;
     timeStepSize: number;
     totalSteps: number;
     size: {

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -77,10 +77,13 @@ export interface TrajectoryFileInfoV2 extends TrajectoryFileInfoBase {
     };
 }
 
-export type TrajectoryFileInfo = TrajectoryFileInfoV1 | TrajectoryFileInfoV2;
+export type TrajectoryFileInfoAny = TrajectoryFileInfoV1 | TrajectoryFileInfoV2;
+
+// This should always point to the latest version
+export type TrajectoryFileInfo = TrajectoryFileInfoV2;
 
 export interface SimulariumFileFormat {
-    trajectoryInfo: TrajectoryFileInfo;
+    trajectoryInfo: TrajectoryFileInfoAny;
     spatialData: VisDataMessage;
     plotData: CachedObservables;
 }

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -1,4 +1,8 @@
-import { TrajectoryFileInfo, TrajectoryFileInfoV1 } from "./types";
+import {
+    TrajectoryFileInfo,
+    TrajectoryFileInfoAny,
+    TrajectoryFileInfoV1,
+} from "./types";
 
 /*
 Handles different trajectory file format versions.
@@ -6,7 +10,7 @@ Currently supported versions: 1, 2
 */
 
 export const updateTrajectoryFileInfoFormat = (
-    msg: TrajectoryFileInfo
+    msg: TrajectoryFileInfoAny
 ): TrajectoryFileInfo => {
     const latestVersion = 2;
     let output = msg;
@@ -43,5 +47,5 @@ export const updateTrajectoryFileInfoFormat = (
             );
     }
 
-    return output;
+    return output as TrajectoryFileInfo;
 };


### PR DESCRIPTION
Resolves part 1 (simularium-viewer portion) of this Jira ticket:  [updateTrajectoryFileInfoFormat's return type should be the latest version of TrajectoryFileInfo](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1382)

In src/viewport/index.tsx, I also pulled up the version conversion `updateTrajectoryFileInfoFormat(msg)` to the top of `simulariumController.trajFileInfoCallback` because `this.visGeometry.handleTrajectoryData()` also takes in `TrajectoryFileInfo` as the argument.

**Pull request recommendations:**

- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description. Ex: _Resolves [gh-##], adds tiff file format support_
- [x] Provide description and context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
