### PR TITLE
bugfix/correct-binary-pre-parse-caching

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -548,8 +548,7 @@ class VisData {
                 this.netBuffer.byteLength
             );
 
-            this.netBuffer = new ArrayBuffer(tmp.byteLength);
-            new Uint8Array(this.netBuffer).set(new Uint8Array(tmp));
+            this.netBuffer = tmp;
         }
     }
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -538,8 +538,18 @@ class VisData {
             new Uint8Array(this.netBuffer).set(new Uint8Array(remainder));
         } else {
             // Append the new data, and wait until eof
-            this.netBuffer = new ArrayBuffer(data.byteLength);
-            new Uint8Array(this.netBuffer).set(new Uint8Array(data));
+            const frame = data.slice(dataStart, data.byteLength);
+            const tmp = new ArrayBuffer(
+                this.netBuffer.byteLength + frame.byteLength
+            );
+            new Uint8Array(tmp).set(new Uint8Array(this.netBuffer));
+            new Uint8Array(tmp).set(
+                new Uint8Array(frame),
+                this.netBuffer.byteLength
+            );
+
+            this.netBuffer = new ArrayBuffer(tmp.byteLength);
+            new Uint8Array(this.netBuffer).set(new Uint8Array(tmp));
         }
     }
 


### PR DESCRIPTION
Problem
=======
Binary broadcasts were being parsed incorrectly. This is an urgently needed fix to get the deployed BE, FE, and data back in sync.

Solution
========
Copy the previous contents of the 'pre-parse' binary cache when appending new cache data.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)