### PR TITLE
Fix/ Can't step to last frame

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -380,8 +380,8 @@ class VisData {
             frame++
         ) {
             const frameTime = this.frameDataCache[frame].time;
-            if (timeNs < frameTime) {
-                this.cacheFrame = Math.max(frame - 1, 0);
+            if (timeNs <= frameTime) {
+                this.cacheFrame = Math.max(frame, 0);
                 break;
             }
         }


### PR DESCRIPTION
Problem
=======
Once I am at the second-to-the-last frame, the "skip 1 frame ahead" button gets disabled and I can't get to the last frame.

Partially resolves (also need changes in simularium-website): [viewer won't step to last time frame](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1357)

Solution
========
The for loop in `VisData.gototime()` that checks which frame to skip to was leaving out the last frame, so I fixed that. This allows the viewer to internally get to the last frame. After this, simularium-website will need similar changes ([see changes in this draft PR](https://github.com/allen-cell-animated/simularium-website/pull/119/files)) to prevent the Skip Frame button from getting disabled prematurely.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
Go to the Jira issue linked above - it's got a test file with a total of 3 frames. If you load it into the viewer, you can skip to the 3rd frame now. 

The slider in the test viewer is wonky, I think there is something wrong with it -- at the 2nd frame out of the 3 (the middle frame), the slider head is not in the middle, and it doesn't go all the way to the end when we skip to the last frame, either. Coupled with the pending simularium-website changes I was able to verify that the changes in this PR result in normal skip/play behaviors. I filed a new [Jira issue](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1397) for the test viewer's slider issues.
