### PR TITLE
Fix/debug and enhance test viewer

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -230,10 +230,9 @@ class Viewer extends React.Component<{}, ViewerState> {
         this.setState({
             totalDuration,
             timeStep: data.timeStepSize,
+            currentFrame: 0,
+            currentTime: 0
         });
-
-        currentTime = 0;
-        currentFrame = 0;
     }
 
     public handleScrubTime(event): void {
@@ -265,11 +264,11 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     public gotoNextFrame(): void {
-        simulariumController.gotoTime(currentTime + this.state.timeStep + 1e-9);
+        simulariumController.gotoTime(this.state.currentTime + this.state.timeStep);
     }
 
     public gotoPreviousFrame(): void {
-        simulariumController.gotoTime(currentTime - this.state.timeStep - 1e-9);
+        simulariumController.gotoTime(this.state.currentTime - this.state.timeStep);
     }
 
     private configureAndLoad() {
@@ -329,19 +328,23 @@ class Viewer extends React.Component<{}, ViewerState> {
                 </button>
 
                 <br />
-                <input
-                    type="range"
-                    min="0"
-                    value={currentTime}
-                    max={this.state.totalDuration}
-                    onChange={this.handleScrubTime}
-                />
-                <button onClick={this.gotoNextFrame.bind(this)}>
-                    Next Frame
-                </button>
                 <button onClick={this.gotoPreviousFrame.bind(this)}>
                     Previous Frame
                 </button>
+                <button onClick={this.gotoNextFrame.bind(this)}>
+                    Next Frame
+                </button>
+                <input
+                    name="slider"
+                    type="range"
+                    min="0"
+                    value={this.state.currentTime}
+                    max={this.state.totalDuration}
+                    onChange={this.handleScrubTime}
+                />
+                <label htmlFor="slider">
+                    {this.state.currentTime} / {this.state.totalDuration}
+                </label>
                 <br />
                 {this.state.particleTypeNames.map((id, i) => {
                     return (

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -264,11 +264,13 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     public gotoNextFrame(): void {
-        simulariumController.gotoTime(this.state.currentTime + this.state.timeStep);
+        const targetTime = parseFloat((this.state.currentTime + this.state.timeStep).toPrecision(4));
+        simulariumController.gotoTime(targetTime);
     }
 
     public gotoPreviousFrame(): void {
-        simulariumController.gotoTime(this.state.currentTime - this.state.timeStep);
+        const targetTime = parseFloat((this.state.currentTime - this.state.timeStep).toPrecision(4));
+        simulariumController.gotoTime(targetTime);
     }
 
     private configureAndLoad() {
@@ -337,7 +339,7 @@ class Viewer extends React.Component<{}, ViewerState> {
                 <input
                     name="slider"
                     type="range"
-                    min="0"
+                    min={0}
                     value={this.state.currentTime}
                     max={this.state.totalDuration}
                     onChange={this.handleScrubTime}


### PR DESCRIPTION
Problem
=======
The test viewer has some usability / outdated code issues that make development/debugging more difficult. When debugging I like to use the test site (since it has much simpler React code) to try to figure out what's a simularium-viewer issue vs. a simularium-website issue.

Solution
========
### Enhancement
* Added a current/total time display next to the slider

### Bug fix
* Added time rounding to `goToNextFrame()` and `goToPreviousFrame()` to fix a bug that broke the Next/Previous Frame buttons sometimes (same fix as described in [this simularium-website PR](https://github.com/allen-cell-animated/simularium-website/pull/121))

### Refactoring (= bug fix???)
* Removed `+ 1e-9` and `- 1e-9` in `goToNextFrame()` and `goToPreviousFrame()` because I don't see why they're needed
* Use `this.state.currentTime` and `this.state.currentFrame` instead of `currentTime` and `currentFrame` variables

The test site is still not perfect but I think these changes will help.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch
2. `npm start`
3. Check it out

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/116952892-ae794680-ac40-11eb-94c2-54cb257ffe3f.png)