### PR TITLE
bugfix/frame-info-parsing

### DIFF
--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -180,7 +180,7 @@ class VisData {
         let start = 0;
 
         const frameDataView = new Float32Array(data);
-	
+
         while (end < lastEOF) {
             // Find the next End of Frame signal
             for (; end < length; end = end + 4) {
@@ -190,12 +190,13 @@ class VisData {
                 }
             }
 
-	    // contains Frame # | Time Stamp | # of Agents
-	    const frameInfoView = frameDataView.subarray(
-		start / 4, (start + 12) / 4
-	    );
+            // contains Frame # | Time Stamp | # of Agents
+            const frameInfoView = frameDataView.subarray(
+                start / 4,
+                (start + 12) / 4
+            );
 
-	    // contains parsable agents
+            // contains parsable agents
             const agentDataView = frameDataView.subarray(
                 (start + 12) / 4,
                 end / 4
@@ -205,7 +206,7 @@ class VisData {
                 time: frameInfoView[1],
                 frameNumber: frameInfoView[0],
             };
-	    const expectedNumAgents = frameInfoView[2];
+            const expectedNumAgents = frameInfoView[2];
             frameDataArray.push(parsedFrameData);
 
             // Parse the frameData
@@ -296,17 +297,18 @@ class VisData {
                     );
                 }
 
-
                 const agent = parseOneAgent(agentSubSetArray);
                 parsedAgentData.push(agent);
                 dataIter = dataIter + chunkLength;
             }
 
-	    const numParsedAgents = parsedAgentData.length;
-	    if(numParsedAgents != expectedNumAgents) {
-		throw new FrontEndError("Mismatch between expected num agents and parsed num agents, possible offset error");
-	    } 
-	    
+            const numParsedAgents = parsedAgentData.length;
+            if (numParsedAgents != expectedNumAgents) {
+                throw new FrontEndError(
+                    "Mismatch between expected num agents and parsed num agents, possible offset error"
+                );
+            }
+
             parsedAgentDataArray.push(parsedAgentData);
 
             start = end + eofPhrase.length;

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -179,10 +179,9 @@ class VisData {
         let end = 0;
         let start = 0;
 
+        const frameDataView = new Float32Array(data);
+	
         while (end < lastEOF) {
-            // contains Frame # | Time Stamp | # of Agents
-            const frameDataView = new Float32Array(data);
-
             // Find the next End of Frame signal
             for (; end < length; end = end + 4) {
                 const curr = byteView.subarray(end, end + eofPhrase.length);
@@ -191,15 +190,22 @@ class VisData {
                 }
             }
 
+	    // contains Frame # | Time Stamp | # of Agents
+	    const frameInfoView = frameDataView.subarray(
+		start / 4, (start + 12) / 4
+	    );
+
+	    // contains parsable agents
             const agentDataView = frameDataView.subarray(
                 (start + 12) / 4,
                 end / 4
             );
 
             const parsedFrameData = {
-                time: frameDataView[1],
-                frameNumber: frameDataView[0],
+                time: frameInfoView[1],
+                frameNumber: frameInfoView[0],
             };
+	    const expectedNumAgents = frameInfoView[2];
             frameDataArray.push(parsedFrameData);
 
             // Parse the frameData
@@ -290,11 +296,17 @@ class VisData {
                     );
                 }
 
+
                 const agent = parseOneAgent(agentSubSetArray);
                 parsedAgentData.push(agent);
                 dataIter = dataIter + chunkLength;
             }
 
+	    const numParsedAgents = parsedAgentData.length;
+	    if(numParsedAgents != expectedNumAgents) {
+		throw new FrontEndError("Mismatch between expected num agents and parsed num agents, possible offset error");
+	    } 
+	    
             parsedAgentDataArray.push(parsedAgentData);
 
             start = end + eofPhrase.length;


### PR DESCRIPTION
Problem
=======
The frame-info is being parsed incorrectly, and therefore stored incorrectly. If a bundle arrives w/ 4 frames, the metadata (not the parsed agents) for the first frame is being saved 4 times.
Addresses [https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1407](AGENTVIZ-1407)

Solution
========
Assign the 'metadata' subarray correctly so that frame metadata is parsed and stored correctly.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Run the viewer locally
2. Log/Observe the `frameDataCache` object in VisData. It should now contain sequential, non-repeated, frame information.
