### PR TITLE
Feature/implement user-set camera transform

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,21 @@
+import { CameraSpec } from "./simularium/types";
+
+export const DEFAULT_CAMERA_Z_POSITION = 120;
+export const DEFAULT_CAMERA_SPEC: CameraSpec = {
+    position: {
+        x: 0,
+        y: 0,
+        z: DEFAULT_CAMERA_Z_POSITION,
+    },
+    lookAtPosition: {
+        x: 0,
+        y: 0,
+        z: 0,
+    },
+    upVector: {
+        x: 0,
+        y: 1,
+        z: 0,
+    },
+    fovDegrees: 75,
+};

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -56,8 +56,8 @@ const NO_AGENT = -1;
 
 const DEFAULT_CAMERA_POSITION: [number, number, number] = [0, 0, 120];
 const DEFAULT_CAMERA_LOOKAT: [number, number, number] = [0, 0, 0];
-const DEFAULT_CAMERA_UP: [number, number, number] = [0, 1, 0];
-const DEFAULT_CAMERA_FOV = 75;
+const DEFAULT_CAMERA_UP: [number, number, number] = [0, 1, 0]; // Must be a unit vector
+const DEFAULT_CAMERA_FOV = 75; // Degrees
 
 const CAMERA_DOLLY_STEP_SIZE = 10;
 export enum RenderStyle {
@@ -375,26 +375,13 @@ class VisGeometry {
             this.resetBounds(DEFAULT_VOLUME_DIMENSIONS);
         }
 
+        // Position and orient the camera
         this.resetCamera();
         this.positionCamera(trajectoryFileInfo.cameraDefault);
     }
 
     public positionCamera(cameraDefault: CameraTransform | undefined): void {
-        if (cameraDefault === undefined) {
-            this.logger.warn(
-                "Using default camera settings since none were provided"
-            );
-
-            this.camera.position.set(...DEFAULT_CAMERA_POSITION);
-            this.initCameraPosition = this.camera.position.clone();
-
-            this.camera.up.set(...DEFAULT_CAMERA_UP);
-
-            this.camera.lookAt(...DEFAULT_CAMERA_LOOKAT);
-            this.controls.target.set(...DEFAULT_CAMERA_LOOKAT);
-
-            this.camera.fov = DEFAULT_CAMERA_FOV;
-        } else {
+        if (cameraDefault) {
             const {
                 position,
                 upVector,
@@ -405,6 +392,7 @@ class VisGeometry {
             this.camera.position.set(position.x, position.y, position.z);
             this.initCameraPosition = this.camera.position.clone();
 
+            // Up vector needs to be a unit vector
             const normalizedUpVector = new Vector3(
                 upVector.x,
                 upVector.y,
@@ -428,8 +416,19 @@ class VisGeometry {
             );
 
             this.camera.fov = fovDegrees;
+        } else {
+            this.logger.warn(
+                "Using default camera settings since none were provided"
+            );
+            this.camera.position.set(...DEFAULT_CAMERA_POSITION);
+            this.initCameraPosition = this.camera.position.clone();
+            this.camera.up.set(...DEFAULT_CAMERA_UP);
+            this.camera.lookAt(...DEFAULT_CAMERA_LOOKAT);
+            this.controls.target.set(...DEFAULT_CAMERA_LOOKAT);
+            this.camera.fov = DEFAULT_CAMERA_FOV;
         }
 
+        // Apply the changes above
         this.camera.updateProjectionMatrix();
     }
 

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -383,9 +383,12 @@ class VisGeometry {
         if (cameraDefault === undefined) {
             this.camera.position.set(...DEFAULT_CAMERA_POSITION);
             this.initCameraPosition = this.camera.position.clone();
+
             this.camera.up.set(...DEFAULT_CAMERA_UP);
+
             this.camera.lookAt(...DEFAULT_CAMERA_LOOKAT);
             this.controls.target.set(...DEFAULT_CAMERA_LOOKAT);
+
             this.camera.fov = DEFAULT_CAMERA_FOV;
         } else {
             const {
@@ -394,9 +397,21 @@ class VisGeometry {
                 lookAtPosition,
                 fovDegrees,
             } = cameraDefault;
+
             this.camera.position.set(position.x, position.y, position.z);
             this.initCameraPosition = this.camera.position.clone();
-            this.camera.up.set(upVector.x, upVector.y, upVector.z);
+
+            const normalizedUpVector = new Vector3(
+                upVector.x,
+                upVector.y,
+                upVector.z
+            ).normalize();
+            this.camera.up.set(
+                normalizedUpVector.x,
+                normalizedUpVector.y,
+                normalizedUpVector.z
+            );
+
             this.camera.lookAt(
                 lookAtPosition.x,
                 lookAtPosition.y,
@@ -407,10 +422,11 @@ class VisGeometry {
                 lookAtPosition.y,
                 lookAtPosition.z
             );
+
             this.camera.fov = fovDegrees;
         }
+
         this.camera.updateProjectionMatrix();
-        console.log(this.camera);
     }
 
     public resetCamera(): void {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -381,6 +381,10 @@ class VisGeometry {
 
     public positionCamera(cameraDefault: CameraTransform | undefined): void {
         if (cameraDefault === undefined) {
+            this.logger.warn(
+                "Using default camera settings since none were provided"
+            );
+
             this.camera.position.set(...DEFAULT_CAMERA_POSITION);
             this.initCameraPosition = this.camera.position.clone();
 

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -350,7 +350,8 @@ class VisGeometry {
     public handleTrajectoryFileInfo(
         trajectoryFileInfo: TrajectoryFileInfo
     ): void {
-        // get bounds.
+        // Create a new bounding box and tick marks and set this.tickIntervalLength (via resetBounds()),
+        // to make it available for use as the length of the scale bar in the UI
         if (trajectoryFileInfo.hasOwnProperty("size")) {
             const bx = trajectoryFileInfo.size.x;
             const by = trajectoryFileInfo.size.y;

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -36,6 +36,7 @@ import * as dat from "dat.gui";
 
 import jsLogger from "js-logger";
 import { ILogger, ILogLevel } from "js-logger";
+import { cloneDeep } from "lodash";
 
 import { DEFAULT_CAMERA_Z_POSITION, DEFAULT_CAMERA_SPEC } from "../constants";
 import { TrajectoryFileInfo, CameraSpec } from "./types";
@@ -380,7 +381,7 @@ class VisGeometry {
             this.logger.warn(
                 "Using default camera settings since none were provided"
             );
-            this.cameraDefault = DEFAULT_CAMERA_SPEC;
+            this.cameraDefault = cloneDeep(DEFAULT_CAMERA_SPEC);
         }
         // Reset then position and orient the camera
         this.resetCamera();

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -53,7 +53,6 @@ const NUM_TICK_INTERVALS = 10;
 const TICK_LENGTH_FACTOR = 100;
 const BOUNDING_BOX_COLOR = new Color(0x6e6e6e);
 const NO_AGENT = -1;
-const DEFAULT_CAMERA_Z_POSITION = 120;
 
 const DEFAULT_CAMERA_POSITION: [number, number, number] = [0, 0, 120];
 const DEFAULT_CAMERA_LOOKAT: [number, number, number] = [0, 0, 0];
@@ -190,7 +189,7 @@ class VisGeometry {
         this.hiddenIds = [];
         this.needToCenterCamera = false;
         this.needToReOrientCamera = false;
-        this.rotateDistance = DEFAULT_CAMERA_Z_POSITION;
+        this.rotateDistance = DEFAULT_CAMERA_POSITION[2];
         // will store data for all agents that are drawing paths
         this.paths = [];
 
@@ -683,7 +682,7 @@ class VisGeometry {
         this.renderer.setClearColor(this.backgroundColor, 1);
         this.renderer.clear();
 
-        this.camera.position.z = DEFAULT_CAMERA_Z_POSITION;
+        this.camera.position.z = DEFAULT_CAMERA_POSITION[2];
         this.initCameraPosition = this.camera.position.clone();
     }
 

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -58,7 +58,7 @@ const DEFAULT_CAMERA_Z_POSITION = 120;
 const DEFAULT_CAMERA_POSITION: [number, number, number] = [0, 0, 120];
 const DEFAULT_CAMERA_LOOKAT: [number, number, number] = [0, 0, 0];
 const DEFAULT_CAMERA_UP: [number, number, number] = [0, 1, 0];
-const DEFAULT_CAMERA_FOV = 50;
+const DEFAULT_CAMERA_FOV = 75;
 
 const CAMERA_DOLLY_STEP_SIZE = 10;
 export enum RenderStyle {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -389,10 +389,11 @@ class VisGeometry {
                 fovDegrees,
             } = cameraDefault;
 
+            // Set camera position
             this.camera.position.set(position.x, position.y, position.z);
             this.initCameraPosition = this.camera.position.clone();
 
-            // Up vector needs to be a unit vector
+            // Set up vector (needs to be a unit vector)
             const normalizedUpVector = new Vector3(
                 upVector.x,
                 upVector.y,
@@ -404,6 +405,7 @@ class VisGeometry {
                 normalizedUpVector.z
             );
 
+            // Set lookat position
             this.camera.lookAt(
                 lookAtPosition.x,
                 lookAtPosition.y,
@@ -415,6 +417,7 @@ class VisGeometry {
                 lookAtPosition.z
             );
 
+            // Set field of view
             this.camera.fov = fovDegrees;
         } else {
             this.logger.warn(

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -391,10 +391,11 @@ class VisGeometry {
     public resetCamera(): void {
         this.followObjectId = NO_AGENT;
         this.controls.reset();
-        this.positionCamera();
+        this.resetCameraPosition();
     }
 
-    public positionCamera(): void {
+    // Sets camera position and orientation to the trajectory's initial (default) values
+    public resetCameraPosition(): void {
         const {
             position,
             upVector,
@@ -402,11 +403,11 @@ class VisGeometry {
             fovDegrees,
         } = this.cameraDefault;
 
-        // Set camera position
+        // Reset camera position
         this.camera.position.set(position.x, position.y, position.z);
         this.initCameraPosition = this.camera.position.clone();
 
-        // Set up vector (needs to be a unit vector)
+        // Reset up vector (needs to be a unit vector)
         const normalizedUpVector = new Vector3(
             upVector.x,
             upVector.y,
@@ -418,7 +419,7 @@ class VisGeometry {
             normalizedUpVector.z
         );
 
-        // Set lookat position
+        // Reset lookat position
         this.camera.lookAt(
             lookAtPosition.x,
             lookAtPosition.y,
@@ -430,7 +431,7 @@ class VisGeometry {
             lookAtPosition.z
         );
 
-        // Set field of view
+        // Reset field of view
         this.camera.fov = fovDegrees;
 
         // Apply the changes above

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -37,7 +37,8 @@ import * as dat from "dat.gui";
 import jsLogger from "js-logger";
 import { ILogger, ILogLevel } from "js-logger";
 
-import { TrajectoryFileInfo, CameraTransform } from "./types";
+import { DEFAULT_CAMERA_Z_POSITION, DEFAULT_CAMERA_SPEC } from "../constants";
+import { TrajectoryFileInfo, CameraSpec } from "./types";
 import { AgentData } from "./VisData";
 
 import MoleculeRenderer from "./rendering/MoleculeRenderer";
@@ -53,7 +54,6 @@ const NUM_TICK_INTERVALS = 10;
 const TICK_LENGTH_FACTOR = 100;
 const BOUNDING_BOX_COLOR = new Color(0x6e6e6e);
 const NO_AGENT = -1;
-const DEFAULT_CAMERA_Z_POSITION = 120;
 const CAMERA_DOLLY_STEP_SIZE = 10;
 export enum RenderStyle {
     WEBGL1_FALLBACK,
@@ -162,7 +162,7 @@ class VisGeometry {
     private needToReOrientCamera: boolean;
     private rotateDistance: number;
     private initCameraPosition: Vector3;
-    private cameraDefault: CameraTransform;
+    private cameraDefault: CameraSpec;
     private fibers: InstancedFiberGroup;
 
     public constructor(loggerLevel: ILogLevel) {
@@ -215,24 +215,7 @@ class VisGeometry {
         this.camera = new PerspectiveCamera(75, 100 / 100, 0.1, 10000);
 
         this.initCameraPosition = this.camera.position.clone();
-        this.cameraDefault = {
-            position: {
-                x: 0,
-                y: 0,
-                z: 120,
-            },
-            lookAtPosition: {
-                x: 0,
-                y: 0,
-                z: 0,
-            },
-            upVector: {
-                x: 0,
-                y: 1,
-                z: 0,
-            },
-            fovDegrees: 75,
-        };
+        this.cameraDefault = DEFAULT_CAMERA_SPEC;
 
         this.dl = new DirectionalLight(0xffffff, 0.6);
         this.hemiLight = new HemisphereLight(0xffffff, 0x000000, 0.5);
@@ -396,6 +379,7 @@ class VisGeometry {
             this.logger.warn(
                 "Using default camera settings since none were provided"
             );
+            this.cameraDefault = DEFAULT_CAMERA_SPEC;
         }
         // Reset then position and orient the camera
         this.resetCamera();

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -216,7 +216,7 @@ class VisGeometry {
         this.camera = new PerspectiveCamera(75, 100 / 100, 0.1, 10000);
 
         this.initCameraPosition = this.camera.position.clone();
-        this.cameraDefault = DEFAULT_CAMERA_SPEC;
+        this.cameraDefault = cloneDeep(DEFAULT_CAMERA_SPEC);
 
         this.dl = new DirectionalLight(0xffffff, 0.6);
         this.hemiLight = new HemisphereLight(0xffffff, 0x000000, 0.5);

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -351,13 +351,14 @@ class VisGeometry {
         return this.renderer.domElement;
     }
 
-    // TODO: rename this function
-    public handleTrajectoryData(trajectoryData: TrajectoryFileInfo): void {
+    public handleTrajectoryFileInfo(
+        trajectoryFileInfo: TrajectoryFileInfo
+    ): void {
         // get bounds.
-        if (trajectoryData.hasOwnProperty("size")) {
-            const bx = trajectoryData.size.x;
-            const by = trajectoryData.size.y;
-            const bz = trajectoryData.size.z;
+        if (trajectoryFileInfo.hasOwnProperty("size")) {
+            const bx = trajectoryFileInfo.size.x;
+            const by = trajectoryFileInfo.size.y;
+            const bz = trajectoryFileInfo.size.z;
             const epsilon = 0.000001;
             if (
                 Math.abs(bx) < epsilon ||
@@ -376,7 +377,7 @@ class VisGeometry {
         }
 
         this.resetCamera();
-        this.positionCamera(trajectoryData.cameraDefault);
+        this.positionCamera(trajectoryFileInfo.cameraDefault);
     }
 
     public positionCamera(cameraDefault: CameraTransform | undefined): void {

--- a/src/simularium/localSimulators/CurveSimulator.ts
+++ b/src/simularium/localSimulators/CurveSimulator.ts
@@ -166,6 +166,24 @@ export default class CurveSim implements IClientSimulatorImpl {
                 y: 12,
                 z: 12,
             },
+            cameraDefault: {
+                position: {
+                    x: 0,
+                    y: 0,
+                    z: 120,
+                },
+                lookAtPosition: {
+                    x: 0,
+                    y: 0,
+                    z: 0,
+                },
+                upVector: {
+                    x: 0,
+                    y: 1,
+                    z: 0,
+                },
+                fovDegrees: 75,
+            },
             typeMapping: typeMapping,
             spatialUnits: {
                 magnitude: 1,

--- a/src/simularium/localSimulators/CurveSimulator.ts
+++ b/src/simularium/localSimulators/CurveSimulator.ts
@@ -8,6 +8,7 @@ import {
     VisDataMessage,
 } from "../types";
 import VisTypes from "../VisTypes";
+import { DEFAULT_CAMERA_SPEC } from "../../constants";
 
 export default class CurveSim implements IClientSimulatorImpl {
     nCurves: number;
@@ -166,24 +167,7 @@ export default class CurveSim implements IClientSimulatorImpl {
                 y: 12,
                 z: 12,
             },
-            cameraDefault: {
-                position: {
-                    x: 0,
-                    y: 0,
-                    z: 120,
-                },
-                lookAtPosition: {
-                    x: 0,
-                    y: 0,
-                    z: 0,
-                },
-                upVector: {
-                    x: 0,
-                    y: 1,
-                    z: 0,
-                },
-                fovDegrees: 75,
-            },
+            cameraDefault: DEFAULT_CAMERA_SPEC,
             typeMapping: typeMapping,
             spatialUnits: {
                 magnitude: 1,

--- a/src/simularium/localSimulators/PointSimulator.ts
+++ b/src/simularium/localSimulators/PointSimulator.ts
@@ -128,6 +128,24 @@ export default class PointSim implements IClientSimulatorImpl {
                 y: 12,
                 z: 12,
             },
+            cameraDefault: {
+                position: {
+                    x: 0,
+                    y: 0,
+                    z: 120,
+                },
+                lookAtPosition: {
+                    x: 0,
+                    y: 0,
+                    z: 0,
+                },
+                upVector: {
+                    x: 0,
+                    y: 1,
+                    z: 0,
+                },
+                fovDegrees: 75,
+            },
             typeMapping: typeMapping,
             spatialUnits: {
                 magnitude: 1,

--- a/src/simularium/localSimulators/PointSimulator.ts
+++ b/src/simularium/localSimulators/PointSimulator.ts
@@ -8,6 +8,7 @@ import {
     VisDataMessage,
 } from "../types";
 import VisTypes from "../VisTypes";
+import { DEFAULT_CAMERA_SPEC } from "../../constants";
 
 export default class PointSim implements IClientSimulatorImpl {
     nPoints: number;
@@ -128,24 +129,7 @@ export default class PointSim implements IClientSimulatorImpl {
                 y: 12,
                 z: 12,
             },
-            cameraDefault: {
-                position: {
-                    x: 0,
-                    y: 0,
-                    z: 120,
-                },
-                lookAtPosition: {
-                    x: 0,
-                    y: 0,
-                    z: 0,
-                },
-                upVector: {
-                    x: 0,
-                    y: 1,
-                    z: 0,
-                },
-                fovDegrees: 75,
-            },
+            cameraDefault: DEFAULT_CAMERA_SPEC,
             typeMapping: typeMapping,
             spatialUnits: {
                 magnitude: 1,

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -15,6 +15,19 @@ export interface VisDataMessage {
     fileName: string;
 }
 
+interface Coordinates3d {
+    x: number;
+    y: number;
+    z: number;
+}
+
+export interface CameraTransform {
+    position: Coordinates3d;
+    lookAtPosition: Coordinates3d;
+    upVector: Coordinates3d;
+    fovDegrees: number;
+}
+
 interface ScatterTrace {
     x: number[];
     y: number[];
@@ -60,11 +73,7 @@ interface TrajectoryFileInfoBase {
     readonly version: number;
     timeStepSize: number;
     totalSteps: number;
-    size: {
-        x: number;
-        y: number;
-        z: number;
-    };
+    size: Coordinates3d;
     typeMapping: EncodedTypeMapping;
 }
 
@@ -81,6 +90,7 @@ export interface TrajectoryFileInfoV2 extends TrajectoryFileInfoBase {
         magnitude: number;
         name: string;
     };
+    cameraDefault: CameraTransform;
 }
 
 export type TrajectoryFileInfoAny = TrajectoryFileInfoV1 | TrajectoryFileInfoV2;

--- a/src/simularium/types.ts
+++ b/src/simularium/types.ts
@@ -21,7 +21,7 @@ interface Coordinates3d {
     z: number;
 }
 
-export interface CameraTransform {
+export interface CameraSpec {
     position: Coordinates3d;
     lookAtPosition: Coordinates3d;
     upVector: Coordinates3d;
@@ -90,7 +90,7 @@ export interface TrajectoryFileInfoV2 extends TrajectoryFileInfoBase {
         magnitude: number;
         name: string;
     };
-    cameraDefault: CameraTransform;
+    cameraDefault: CameraSpec;
 }
 
 export type TrajectoryFileInfoAny = TrajectoryFileInfoV1 | TrajectoryFileInfoV2;

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -46,6 +46,24 @@ export const updateTrajectoryFileInfoFormat = (
                     magnitude: 1,
                     name: "s",
                 },
+                cameraDefault: {
+                    position: {
+                        x: 0,
+                        y: 0,
+                        z: 120,
+                    },
+                    lookAtPosition: {
+                        x: 0,
+                        y: 0,
+                        z: 0,
+                    },
+                    upVector: {
+                        x: 0,
+                        y: 1,
+                        z: 0,
+                    },
+                    fovDegrees: 50,
+                },
                 timeStepSize: v1Data.timeStepSize,
                 totalSteps: v1Data.totalSteps,
                 typeMapping: v1Data.typeMapping,

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -69,6 +69,9 @@ export const updateTrajectoryFileInfoFormat = (
                 typeMapping: v1Data.typeMapping,
                 version: 2,
             };
+            console.warn(
+                "Using default camera settings since none were provided"
+            );
             break;
         default:
             throw new RangeError(VERSION_NUM_ERROR + msg.version);

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -62,7 +62,7 @@ export const updateTrajectoryFileInfoFormat = (
                         y: 1,
                         z: 0,
                     },
-                    fovDegrees: 50,
+                    fovDegrees: 75,
                 },
                 timeStepSize: v1Data.timeStepSize,
                 totalSteps: v1Data.totalSteps,

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -1,5 +1,6 @@
 import * as si from "si-prefix";
 
+import { DEFAULT_CAMERA_SPEC } from "../constants";
 import {
     TrajectoryFileInfo,
     TrajectoryFileInfoAny,
@@ -46,24 +47,7 @@ export const updateTrajectoryFileInfoFormat = (
                     magnitude: 1,
                     name: "s",
                 },
-                cameraDefault: {
-                    position: {
-                        x: 0,
-                        y: 0,
-                        z: 120,
-                    },
-                    lookAtPosition: {
-                        x: 0,
-                        y: 0,
-                        z: 0,
-                    },
-                    upVector: {
-                        x: 0,
-                        y: 1,
-                        z: 0,
-                    },
-                    fovDegrees: 75,
-                },
+                cameraDefault: DEFAULT_CAMERA_SPEC,
                 timeStepSize: v1Data.timeStepSize,
                 totalSteps: v1Data.totalSteps,
                 typeMapping: v1Data.typeMapping,

--- a/src/test/versionHandlers.test.ts
+++ b/src/test/versionHandlers.test.ts
@@ -52,6 +52,24 @@ const v2Data = {
         y: 100,
         z: 100,
     },
+    cameraDefault: {
+        position: {
+            x: 0,
+            y: 0,
+            z: 120,
+        },
+        lookAtPosition: {
+            x: 0,
+            y: 0,
+            z: 0,
+        },
+        upVector: {
+            x: 0,
+            y: 1,
+            z: 0,
+        },
+        fovDegrees: 75,
+    },
     spatialUnits: {
         magnitude: 1.5,
         name: "nm",

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -218,7 +218,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             // Create a new bounding box and tick marks (via resetBounds()) and set
             // VisGeometry.tickIntervalLength, to make it available for use as the length of the
             // scale bar in the UI
-            this.visGeometry.handleTrajectoryData(trajectoryFileInfo);
+            this.visGeometry.handleTrajectoryFileInfo(trajectoryFileInfo);
 
             simulariumController.tickIntervalLength = this.visGeometry.tickIntervalLength;
 

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -215,11 +215,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                 msg
             );
 
-            // Create a new bounding box and tick marks (via resetBounds()) and set
-            // VisGeometry.tickIntervalLength, to make it available for use as the length of the
-            // scale bar in the UI
             this.visGeometry.handleTrajectoryFileInfo(trajectoryFileInfo);
-
             simulariumController.tickIntervalLength = this.visGeometry.tickIntervalLength;
 
             try {


### PR DESCRIPTION
Problem
=======
The viewer doesn't do anything yet with the new `cameraDefault` data (camera position and orientation) in v2 trajectory files.

Resolves: [implement set initial camera transform from data](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1082)

Solution
========
Enable the viewer to use the `cameraDefault` data to set the initial camera orientation and position per user's specifications

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires updated or new tests

Key files / Change summary:
---------------
* src/simularium/types.ts - Add `cameraDefault` to the `TrajectoryFileInfoV2` interface
* src/simularium/versionHandlers.ts - Add a `cameraDefault` block with default values to all v1 trajectories when converting to v2
* src/simularium/VisGeometry.ts
    * Created a `cameraDefault` property to hold the default camera transform values initially and to hold custom values if they are received
    * Created a `positionCamera()` method which does three.js operations to position and orient the camera
    * Invoke `positionCamera()` from `resetCamera()` so that any time a new file is loaded or when the user clicks the Reset Camera button, the camera's position and orientation is reset to what's in `this.cameraDefault` in addition to the camera's `OrbitControls` being reset
    * Minor refactoring
        * Removed `resetCameraOnNewScene` property because it should just always be `true` (per @toloudis 's suggestion)
        * Renamed `handleTrajectoryData()` method as `handleTrajectoryFileInfo()` to make it more accurate and less confusing

Steps to Verify:
----------------
1. Download [this test file](https://drive.google.com/file/d/1DJF8OYcFEIoh1KriNzqhKC5F2qAprsaN/view?usp=sharing). This file contains the following info in `trajectoryFileInfo`:
```
"cameraDefault":{
    "position":{
        "x":120,
        "y":0,
        "z":120
    },
    "lookAtPosition":{
        "x":0,
        "y":0,
        "z":0
    },
    "upVector":{
        "x":1,
        "y":2,
        "z":0
    },
    "fovDegrees": 90
}
```
2. Load it into our staging web site, notice you're looking at the bounding box straight-on (the camera params above don't have an effect)
3. Pull this branch, `npm start` and load it into the example viewer. Notice the bounding box is now farther away, rotated, and seen from a horizontally offset position

### Note
* The default fov angle [specified in simulariumio ](https://github.com/allen-cell-animated/simulariumio/blob/master/file_format.md) is 50 degrees. I talked with @blairlyons about this and it should be 75 degrees instead to match what's been the hard-coded default in the viewer. So I used 75 as the default. Blair will change it in simulariumio as well.
* If default values were used because the file was converted from v1 to v2 or because none were specified, then simularium-viewer emits a console warning about it. I don't think this will be visible to users on the simularium-website end though -- do we need it to be?