### PR TITLE
Fix/floating point time errors

### DIFF
--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -157,20 +157,13 @@ export class LocalFileSimulator implements ISimulator {
     }
 
     public gotoRemoteSimulationTime(timeNs: number): void {
-        for (
-            let frame = 0,
-                numFrames = this.simulariumFile.spatialData.bundleData.length;
-            frame < numFrames;
-            frame++
-        ) {
-            const frameTime = this.simulariumFile.spatialData.bundleData[frame]
-                .time;
-            if (timeNs <= frameTime) {
-                const theFrameNumber = Math.max(frame, 0);
-                this.onTrajectoryDataArrive(this.getFrame(theFrameNumber));
-                break;
-            }
-        }
+        const { bundleData } = this.simulariumFile.spatialData;
+        const frameNumber = bundleData.findIndex(
+            (bundleData) => bundleData.time >= timeNs
+        );
+
+        // frameNumber is -1 if findIndex() above doesn't find a match
+        this.onTrajectoryDataArrive(this.getFrame(Math.max(frameNumber, 0)));
     }
 
     public requestTrajectoryFileInfo(_fileName: string): void {

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -169,9 +169,7 @@ export class LocalFileSimulator implements ISimulator {
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         if (frameNumber !== -1) {
-            this.onTrajectoryDataArrive(
-                this.getFrame(Math.max(frameNumber, 0))
-            );
+            this.requestSingleFrame(Math.max(frameNumber, 0));
         }
     }
 

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -1,7 +1,7 @@
 import jsLogger from "js-logger";
 import { ILogger } from "js-logger";
 
-import { compareFloats } from "../util";
+import { compareTimes } from "../util";
 
 import {
     VisDataMessage,
@@ -164,7 +164,7 @@ export class LocalFileSimulator implements ISimulator {
 
         // Find the index of the frame that has the time matching our target time
         const frameNumber = bundleData.findIndex((bundleData) => {
-            return compareFloats(bundleData.time, timeNs, timeStepSize) === 0;
+            return compareTimes(bundleData.time, timeNs, timeStepSize) === 0;
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -169,7 +169,7 @@ export class LocalFileSimulator implements ISimulator {
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         if (frameNumber !== -1) {
-            this.requestSingleFrame(Math.max(frameNumber, 0));
+            this.requestSingleFrame(frameNumber);
         }
     }
 

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -1,6 +1,8 @@
 import jsLogger from "js-logger";
 import { ILogger } from "js-logger";
 
+import { compareFloats } from "../util";
+
 import {
     VisDataMessage,
     VisDataFrame,
@@ -158,9 +160,12 @@ export class LocalFileSimulator implements ISimulator {
 
     public gotoRemoteSimulationTime(timeNs: number): void {
         const { bundleData } = this.simulariumFile.spatialData;
-        const frameNumber = bundleData.findIndex(
-            (bundleData) => bundleData.time >= timeNs
-        );
+        const { timeStepSize } = this.simulariumFile.trajectoryInfo;
+
+        // Find the index of the frame that has the time matching our target time
+        const frameNumber = bundleData.findIndex((bundleData) => {
+            compareFloats(bundleData.time, timeNs, timeStepSize) === 0;
+        });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         this.onTrajectoryDataArrive(this.getFrame(Math.max(frameNumber, 0)));

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -168,7 +168,11 @@ export class LocalFileSimulator implements ISimulator {
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
-        this.onTrajectoryDataArrive(this.getFrame(Math.max(frameNumber, 0)));
+        if (frameNumber !== -1) {
+            this.onTrajectoryDataArrive(
+                this.getFrame(Math.max(frameNumber, 0))
+            );
+        }
     }
 
     public requestTrajectoryFileInfo(_fileName: string): void {

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -164,7 +164,7 @@ export class LocalFileSimulator implements ISimulator {
 
         // Find the index of the frame that has the time matching our target time
         const frameNumber = bundleData.findIndex((bundleData) => {
-            compareFloats(bundleData.time, timeNs, timeStepSize) === 0;
+            return compareFloats(bundleData.time, timeNs, timeStepSize) === 0;
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -376,20 +376,30 @@ class VisData {
      *   Functions to check update
      * */
     public hasLocalCacheForTime(timeNs: number): boolean {
+        const firstFrameTime = this.frameDataCache[0].time;
+        const lastFrameTime = this.frameDataCache[
+            this.frameDataCache.length - 1
+        ].time;
+
+        // Edge cases
         if (
             this.frameDataCache.length > 0 &&
             timeNs === 0 &&
-            this.frameDataCache[0].time <= Number.EPSILON // allow for floating point errors
+            firstFrameTime <= Number.EPSILON // allow for floating point errors
         ) {
+            // First frame is required and it exists in local cache
             return true;
         } else if (this.frameDataCache.length < 2) {
+            // Local cache only has 1 frame but we need something other than the first frame
             return false;
         }
 
-        return (
-            this.frameDataCache[0].time <= timeNs &&
-            this.frameDataCache[this.frameDataCache.length - 1].time >= timeNs
-        );
+        // Non-edge cases
+        const notLessThanFirstFrameTime =
+            compareFloats(timeNs, firstFrameTime, this.timeStepSize) !== -1;
+        const notGreaterThanLastFrameTime =
+            compareFloats(timeNs, lastFrameTime, this.timeStepSize) !== 1;
+        return notLessThanFirstFrameTime && notGreaterThanLastFrameTime;
     }
 
     public gotoTime(timeNs: number): void {

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -396,10 +396,11 @@ class VisData {
         this.cacheFrame = -1;
 
         // Find the index of the frame that has the time matching our target time
-        const frameNumber = this.frameDataCache.findIndex(
-            (frameData) =>
+        const frameNumber = this.frameDataCache.findIndex((frameData) => {
+            return (
                 compareFloats(frameData.time, timeNs, this.timeStepSize) === 0
-        );
+            );
+        });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         this.cacheFrame = Math.max(frameNumber, 0);

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -381,20 +381,19 @@ class VisData {
             this.frameDataCache.length - 1
         ].time;
 
-        // Edge cases
+        // Deal with some special cases first
         if (
             this.frameDataCache.length > 0 &&
             timeNs === 0 &&
             firstFrameTime <= Number.EPSILON // allow for floating point errors
         ) {
-            // First frame is required and it exists in local cache
+            // t = 0 is needed, the first frame time is 0, and it exists in local cache
             return true;
         } else if (this.frameDataCache.length < 2) {
             // Local cache only has 1 frame but we need something other than the first frame
             return false;
         }
 
-        // Non-edge cases
         const notLessThanFirstFrameTime =
             compareFloats(timeNs, firstFrameTime, this.timeStepSize) !== -1;
         const notGreaterThanLastFrameTime =
@@ -413,7 +412,9 @@ class VisData {
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
-        this.cacheFrame = Math.max(frameNumber, 0);
+        if (frameNumber !== -1) {
+            this.cacheFrame = Math.max(frameNumber, 0);
+        }
     }
 
     public atLatestFrame(): boolean {

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -1,6 +1,6 @@
 import { difference } from "lodash";
 
-import { compareFloats } from "../util";
+import { compareTimes } from "../util";
 
 import * as util from "./ThreadUtil";
 import {
@@ -395,9 +395,9 @@ class VisData {
         }
 
         const notLessThanFirstFrameTime =
-            compareFloats(timeNs, firstFrameTime, this.timeStepSize) !== -1;
+            compareTimes(timeNs, firstFrameTime, this.timeStepSize) !== -1;
         const notGreaterThanLastFrameTime =
-            compareFloats(timeNs, lastFrameTime, this.timeStepSize) !== 1;
+            compareTimes(timeNs, lastFrameTime, this.timeStepSize) !== 1;
         return notLessThanFirstFrameTime && notGreaterThanLastFrameTime;
     }
 
@@ -407,7 +407,7 @@ class VisData {
         // Find the index of the frame that has the time matching our target time
         const frameNumber = this.frameDataCache.findIndex((frameData) => {
             return (
-                compareFloats(frameData.time, timeNs, this.timeStepSize) === 0
+                compareTimes(frameData.time, timeNs, this.timeStepSize) === 0
             );
         });
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -413,7 +413,7 @@ class VisData {
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         if (frameNumber !== -1) {
-            this.cacheFrame = Math.max(frameNumber, 0);
+            this.cacheFrame = frameNumber;
         }
     }
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -1,4 +1,7 @@
 import { difference } from "lodash";
+
+import { compareFloats } from "../util";
+
 import * as util from "./ThreadUtil";
 import {
     TrajectoryFileInfo,
@@ -46,6 +49,9 @@ class VisData {
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     private _dragAndDropFileInfo: TrajectoryFileInfo | null;
+
+    public timeStepSize: number;
+
     /**
      *   Parses a stream of data sent from the backend
      *
@@ -348,6 +354,7 @@ class VisData {
         this.frameToWaitFor = 0;
         this.lockedForFrame = false;
         this.netBuffer = new ArrayBuffer(0);
+        this.timeStepSize = 0;
     }
 
     //get time() { return this.cacheFrame < this.frameDataCache.length ? this.frameDataCache[this.cacheFrame] : -1 }
@@ -387,8 +394,11 @@ class VisData {
 
     public gotoTime(timeNs: number): void {
         this.cacheFrame = -1;
+
+        // Find the index of the frame that has the time matching our target time
         const frameNumber = this.frameDataCache.findIndex(
-            (frameData) => frameData.time >= timeNs
+            (frameData) =>
+                compareFloats(frameData.time, timeNs, this.timeStepSize) === 0
         );
 
         // frameNumber is -1 if findIndex() above doesn't find a match

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -387,18 +387,12 @@ class VisData {
 
     public gotoTime(timeNs: number): void {
         this.cacheFrame = -1;
+        const frameNumber = this.frameDataCache.findIndex(
+            (frameData) => frameData.time >= timeNs
+        );
 
-        for (
-            let frame = 0, numFrames = this.frameDataCache.length;
-            frame < numFrames;
-            frame++
-        ) {
-            const frameTime = this.frameDataCache[frame].time;
-            if (timeNs <= frameTime) {
-                this.cacheFrame = Math.max(frame, 0);
-                break;
-            }
-        }
+        // frameNumber is -1 if findIndex() above doesn't find a match
+        this.cacheFrame = Math.max(frameNumber, 0);
     }
 
     public atLatestFrame(): boolean {

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -1,11 +1,11 @@
-import { compareFloats } from "../util";
+import { compareTimes } from "../util";
 
 describe("util", () => {
-    describe("compareFloats", () => {
+    describe("compareTimes", () => {
         const PRECISION_REF = 0.1;
 
-        test("it correctly determines number1 > number2", () => {
-            const result = compareFloats(
+        test("it correctly determines time1 > time2", () => {
+            const result = compareTimes(
                 14.699999809265137,
                 14.6,
                 PRECISION_REF
@@ -13,8 +13,8 @@ describe("util", () => {
             expect(result).toEqual(1);
         });
 
-        test("it correctly determines number1 < number2", () => {
-            const result = compareFloats(
+        test("it correctly determines time1 < time2", () => {
+            const result = compareTimes(
                 14.600000381469727,
                 14.699999809265137,
                 PRECISION_REF
@@ -22,8 +22,8 @@ describe("util", () => {
             expect(result).toEqual(-1);
         });
 
-        test("it correctly determines number1 ~= number2 when number1 is slightly greater", () => {
-            const result = compareFloats(
+        test("it correctly determines time1 ~= time2 when time1 is slightly greater", () => {
+            const result = compareTimes(
                 14.700000190734863,
                 14.699999809265137,
                 PRECISION_REF
@@ -31,8 +31,8 @@ describe("util", () => {
             expect(result).toEqual(0);
         });
 
-        test("it correctly determines number1 ~= number2 when number1 is slightly less", () => {
-            const result = compareFloats(
+        test("it correctly determines time1 ~= time2 when time1 is slightly less", () => {
+            const result = compareTimes(
                 14.699999809265137,
                 14.7,
                 PRECISION_REF
@@ -40,8 +40,8 @@ describe("util", () => {
             expect(result).toEqual(0);
         });
 
-        test("it correctly determines number1 ~= number2 when numbers are equal", () => {
-            const result = compareFloats(0.005, 0.005, 0.005);
+        test("it correctly determines time1 ~= time2 when numbers are equal", () => {
+            const result = compareTimes(0.005, 0.005, 0.005);
             expect(result).toEqual(0);
         });
     });

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -1,0 +1,48 @@
+import { compareFloats } from "../util";
+
+describe("util", () => {
+    describe("compareFloats", () => {
+        const PRECISION_REF = 0.1;
+        const PRECISION_FACTOR = 0.01;
+
+        test("it correctly determines number1 > number2", () => {
+            const result = compareFloats(
+                14.699999809265137,
+                14.6,
+                PRECISION_REF,
+                PRECISION_FACTOR
+            );
+            expect(result).toEqual(1);
+        });
+
+        test("it correctly determines number1 < number2", () => {
+            const result = compareFloats(
+                14.600000381469727,
+                14.699999809265137,
+                PRECISION_REF,
+                PRECISION_FACTOR
+            );
+            expect(result).toEqual(-1);
+        });
+
+        test("it correctly determines number1 ~= number2 when number1 is slightly greater", () => {
+            const result = compareFloats(
+                14.700000190734863,
+                14.699999809265137,
+                PRECISION_REF,
+                PRECISION_FACTOR
+            );
+            expect(result).toEqual(0);
+        });
+
+        test("it correctly determines number1 ~= number2 when number1 is slightly less", () => {
+            const result = compareFloats(
+                14.699999809265137,
+                14.7,
+                PRECISION_REF,
+                PRECISION_FACTOR
+            );
+            expect(result).toEqual(0);
+        });
+    });
+});

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -39,5 +39,10 @@ describe("util", () => {
             );
             expect(result).toEqual(0);
         });
+
+        test("it correctly determines number1 ~= number2 when numbers are equal", () => {
+            const result = compareFloats(0.005, 0.005, 0.005);
+            expect(result).toEqual(0);
+        });
     });
 });

--- a/src/test/util.test.ts
+++ b/src/test/util.test.ts
@@ -3,14 +3,12 @@ import { compareFloats } from "../util";
 describe("util", () => {
     describe("compareFloats", () => {
         const PRECISION_REF = 0.1;
-        const PRECISION_FACTOR = 0.01;
 
         test("it correctly determines number1 > number2", () => {
             const result = compareFloats(
                 14.699999809265137,
                 14.6,
-                PRECISION_REF,
-                PRECISION_FACTOR
+                PRECISION_REF
             );
             expect(result).toEqual(1);
         });
@@ -19,8 +17,7 @@ describe("util", () => {
             const result = compareFloats(
                 14.600000381469727,
                 14.699999809265137,
-                PRECISION_REF,
-                PRECISION_FACTOR
+                PRECISION_REF
             );
             expect(result).toEqual(-1);
         });
@@ -29,8 +26,7 @@ describe("util", () => {
             const result = compareFloats(
                 14.700000190734863,
                 14.699999809265137,
-                PRECISION_REF,
-                PRECISION_FACTOR
+                PRECISION_REF
             );
             expect(result).toEqual(0);
         });
@@ -39,8 +35,7 @@ describe("util", () => {
             const result = compareFloats(
                 14.699999809265137,
                 14.7,
-                PRECISION_REF,
-                PRECISION_FACTOR
+                PRECISION_REF
             );
             expect(result).toEqual(0);
         });

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,8 +18,7 @@ export const compareFloats = (
         0 if number1 ~= number2
     */
 
-    // 0.01 is arbitrary
-    const epsilon = precisionRef * 0.01;
+    const epsilon = precisionRef * 0.01; // 0.01 is arbitrary
     if (number1 - epsilon > number2) return 1;
     if (number1 + epsilon < number2) return -1;
     return 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,9 +1,7 @@
-// TODO: Put precisionFactor as global constant
 export const compareFloats = (
     number1: number,
     number2: number,
-    precisionRef: number,
-    precisionFactor = 1
+    precisionRef: number
 ): number => {
     /*
     Compares 2 numbers by using an epsilon padding to bypass any floating point precision issues.
@@ -13,8 +11,6 @@ export const compareFloats = (
         number2:            Any number
         precisionRef:       A reference number to use for precision, e.g. a time step size if
                             you're comparing 2 time values in a time series
-        precisionFactor:    precisionRef will be multiplied by this number to determine epsilon,
-                            e.g., 0.01 to use 1/100 of a time step size as epsilon
 
     Returns:
         1 if number1 > number2
@@ -22,7 +18,8 @@ export const compareFloats = (
         0 if number1 ~= number2
     */
 
-    const epsilon = precisionRef * precisionFactor;
+    // 0.01 is arbitrary
+    const epsilon = precisionRef * 0.01;
     if (number1 - epsilon > number2) return 1;
     if (number1 + epsilon < number2) return -1;
     return 0;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,29 @@
+// TODO: Put precisionFactor as global constant
+export const compareFloats = (
+    number1: number,
+    number2: number,
+    precisionRef: number,
+    precisionFactor = 1
+): number => {
+    /*
+    Compares 2 numbers by using an epsilon padding to bypass any floating point precision issues.
+
+    Params:
+        number1:            Any number
+        number2:            Any number
+        precisionRef:       A reference number to use for precision, e.g. a time step size if
+                            you're comparing 2 time values in a time series
+        precisionFactor:    precisionRef will be multiplied by this number to determine epsilon,
+                            e.g., 0.01 to use 1/100 of a time step size as epsilon
+
+    Returns:
+        1 if number1 > number2
+        -1 if number1 < number2
+        0 if number1 ~= number2
+    */
+
+    const epsilon = precisionRef * precisionFactor;
+    if (number1 - epsilon > number2) return 1;
+    if (number1 + epsilon < number2) return -1;
+    return 0;
+};

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,25 +1,26 @@
-export const compareFloats = (
-    number1: number,
-    number2: number,
-    precisionRef: number
+export const compareTimes = (
+    time1: number,
+    time2: number,
+    timeStepSize: number,
+    stepSizeFraction = 0.01
 ): number => {
     /*
-    Compares 2 numbers by using an epsilon padding to bypass any floating point precision issues.
+    Compares two time values in a series by seeing whether they are within some
+    small fraction of the time step size.
 
     Params:
-        number1:            Any number
-        number2:            Any number
-        precisionRef:       A reference number to use for precision, e.g. a time step size if
-                            you're comparing 2 time values in a time series
+        time1:          Any number
+        time2:          Any number
+        timeStepSize:   The step size in a time series
 
     Returns:
-        1 if number1 > number2
-        -1 if number1 < number2
-        0 if number1 ~= number2
+        1 if time1 > time2
+        -1 if time1 < time2
+        0 if time1 ~= time2
     */
 
-    const epsilon = precisionRef * 0.01; // 0.01 is arbitrary
-    if (number1 - epsilon > number2) return 1;
-    if (number1 + epsilon < number2) return -1;
+    const epsilon = timeStepSize * stepSizeFraction;
+    if (time1 - epsilon > time2) return 1;
+    if (time1 + epsilon < time2) return -1;
     return 0;
 };

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -214,7 +214,9 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             const trajectoryFileInfo: TrajectoryFileInfo = updateTrajectoryFileInfoFormat(
                 msg
             );
-
+            
+            simulariumController.visData.timeStepSize = trajectoryFileInfo.timeStepSize;
+            
             this.visGeometry.handleTrajectoryFileInfo(trajectoryFileInfo);
             simulariumController.tickIntervalLength = this.visGeometry.tickIntervalLength;
 


### PR DESCRIPTION
Problem
=======
Resolves [this bug](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1420) and hopefully prevents/fixes similar floating point time value bugs unbeknownst to us as well.

Solution
========
I added a `compareFloats()` util function that takes 2 numbers and lets us know which one is greater, or if they are pretty much equal with a configurable epsilon padding, so we can compare time values in functions like `VisData.gotoTime()` without getting thwarted by floating point precision issues.

`SimulariumController.gotoTime()` (which currently triggers bugs) calls either `this.visData.gotoTime()` or `this.simulator.gotoRemoteSimulationTime()` depending on whether we have frames cached in VisData or not. Time comparison logic is performed in `VisData.gotoTime()`, `VisData.hasLocalCacheForTime()`, and in `LocalFileSimulator.gotoRemoteSimulationTime()`. In these methods I now avoid floating point related errors by using the new `compareFloats()` util function to compare time values rather than just using greater/less/equal operators.

Thanks @toloudis for much help/advice.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires updated or new tests

Change summary:
---------------
* src/util.ts - new file containing the new `compareFloats()` function
* src/simularium/LocalFileSimulator.ts - refactoring for readability + use `compareFloats()` instead of plain comparisons
* src/simularium/VisData.ts - more refactoring for readability + use `compareFloats()` instead of plain comparisons

When `compareFloats()` is used to compare time values (like in this PR), epsilon is determined by the time step size for the trajectory file (epsilon = time step size * 0.01).

Steps to Verify:
----------------
1. Pull this branch
2. Run a local version of simularium-website with this branch as its viewer 
3. Load endocytosis
3. Try to repro the bug at the top of this PR description or just try to break the slider in general

After this merge there shouldn't be any bugs affecting the slider/playback buttons for networked trajectories. 🤞🏻🤞🏻 At least I'm not aware of any. There are, however, some non-floating point issues to be worked out for local/URL-download file playback though.
