### PR TITLE
Fix/playback not resuming after skipping to a point in time

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export type {
 } from "./simularium";
 export { Orchestrator, RenderStyle, SimulariumController };
 export { RemoteSimulator, DummyRemoteSimulator } from "./simularium";
+export { compareTimes } from "./util";
 
 export default Viewport;

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -376,23 +376,14 @@ class VisData {
      *   Functions to check update
      * */
     public hasLocalCacheForTime(timeNs: number): boolean {
+        if (this.frameDataCache.length < 1) {
+            return false;
+        }
+
         const firstFrameTime = this.frameDataCache[0].time;
         const lastFrameTime = this.frameDataCache[
             this.frameDataCache.length - 1
         ].time;
-
-        // Deal with some special cases first
-        if (
-            this.frameDataCache.length > 0 &&
-            timeNs === 0 &&
-            firstFrameTime <= Number.EPSILON // allow for floating point errors
-        ) {
-            // t = 0 is needed, the first frame time is 0, and it exists in local cache
-            return true;
-        } else if (this.frameDataCache.length < 2) {
-            // Local cache only has 1 frame but we need something other than the first frame
-            return false;
-        }
 
         const notLessThanFirstFrameTime =
             compareTimes(timeNs, firstFrameTime, this.timeStepSize) !== -1;


### PR DESCRIPTION
Problem
=======
I was testing v2.9.1 (floating point error fix) again before updating the viewer version on simularium-website and noticed this bug:
1. Play a networked simulation
2. While it's playing, click ahead in a point in time
3. The time skips to where you clicked, but it doesn't resume playing there like it's supposed to

Solution
========
I realized I was getting a console error saying "can't get `time` of undefined" in the first line of `VisData.hasLocalCacheForTime()` when this bug occurs. So I put in a check to just return false if the frame data cache is empty.

I thought in my last PR that lines 384-396 in VisData might not be necessary anymore, but I kept them in because I figured no harm. Turns out it causes some weird behavior now (namely starting off the endocytosis simulation at the second frame instead of the first). So I took them out.

I also exported the `compareTimes()` util so we can use it in simularium-website. Namely to replace arbitrary rounding of float values in places like [this](https://github.com/allen-cell-animated/simularium-website/blob/master/src/containers/ViewerPanel/index.tsx#L303).

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Pull this branch, link it to your local simularium-website branch, and try to break the slider on networked trajectories. (I also have the ambition of actually writing UI tests as outlined in this new [Jira issue](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1436), at some point)
