### PR TITLE
Fix/local playback bugs

### DIFF
--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -159,7 +159,6 @@ export class LocalFileSimulator implements ISimulator {
     }
 
     public gotoRemoteSimulationTime(timeNs: number): void {
-        console.log(`LocalFileSimulator.gotoRemoteSimulationTime(${timeNs})`);
         const { bundleData } = this.simulariumFile.spatialData;
         const { timeStepSize } = this.simulariumFile.trajectoryInfo;
 
@@ -172,8 +171,6 @@ export class LocalFileSimulator implements ISimulator {
         if (frameNumber !== -1) {
             this.currentPlaybackFrameIndex = frameNumber;
             this.requestSingleFrame(frameNumber);
-        } else {
-            throw `No frame matching the time ${timeNs} was found in the bundleData`;
         }
     }
 

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -170,6 +170,7 @@ export class LocalFileSimulator implements ISimulator {
 
         // frameNumber is -1 if findIndex() above doesn't find a match
         if (frameNumber !== -1) {
+            this.currentPlaybackFrameIndex = frameNumber;
             this.requestSingleFrame(frameNumber);
         } else {
             throw `No frame matching the time ${timeNs} was found in the bundleData`;

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -159,6 +159,7 @@ export class LocalFileSimulator implements ISimulator {
     }
 
     public gotoRemoteSimulationTime(timeNs: number): void {
+        console.log(`LocalFileSimulator.gotoRemoteSimulationTime(${timeNs})`);
         const { bundleData } = this.simulariumFile.spatialData;
         const { timeStepSize } = this.simulariumFile.trajectoryInfo;
 
@@ -170,6 +171,8 @@ export class LocalFileSimulator implements ISimulator {
         // frameNumber is -1 if findIndex() above doesn't find a match
         if (frameNumber !== -1) {
             this.requestSingleFrame(frameNumber);
+        } else {
+            throw `No frame matching the time ${timeNs} was found in the bundleData`;
         }
     }
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -389,18 +389,10 @@ class VisData {
             compareTimes(timeNs, firstFrameTime, this.timeStepSize) !== -1;
         const notGreaterThanLastFrameTime =
             compareTimes(timeNs, lastFrameTime, this.timeStepSize) !== 1;
-
-        if (
-            notLessThanFirstFrameTime &&
-            notGreaterThanLastFrameTime === false
-        ) {
-            console.log("no local cache for time");
-        }
         return notLessThanFirstFrameTime && notGreaterThanLastFrameTime;
     }
 
     public gotoTime(timeNs: number): void {
-        console.log(`VisData.gotoTime(${timeNs})`);
         this.cacheFrame = -1;
 
         // Find the index of the frame that has the time matching our target time
@@ -411,9 +403,7 @@ class VisData {
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
-        if (frameNumber === -1) {
-            throw `No frame matching the time ${timeNs} was found in the cache`;
-        } else {
+        if (frameNumber !== -1) {
             this.cacheFrame = frameNumber;
         }
     }
@@ -454,7 +444,6 @@ class VisData {
     }
 
     public clearCache(): void {
-        console.log("clearing cache:", this.frameDataCache.length);
         this.frameCache = [];
         this.frameDataCache = [];
         this.cacheFrame = -1;

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -389,10 +389,18 @@ class VisData {
             compareTimes(timeNs, firstFrameTime, this.timeStepSize) !== -1;
         const notGreaterThanLastFrameTime =
             compareTimes(timeNs, lastFrameTime, this.timeStepSize) !== 1;
+
+        if (
+            notLessThanFirstFrameTime &&
+            notGreaterThanLastFrameTime === false
+        ) {
+            console.log("no local cache for time");
+        }
         return notLessThanFirstFrameTime && notGreaterThanLastFrameTime;
     }
 
     public gotoTime(timeNs: number): void {
+        console.log(`VisData.gotoTime(${timeNs})`);
         this.cacheFrame = -1;
 
         // Find the index of the frame that has the time matching our target time
@@ -403,7 +411,9 @@ class VisData {
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match
-        if (frameNumber !== -1) {
+        if (frameNumber === -1) {
+            throw `No frame matching the time ${timeNs} was found in the cache`;
+        } else {
             this.cacheFrame = frameNumber;
         }
     }
@@ -444,6 +454,7 @@ class VisData {
     }
 
     public clearCache(): void {
+        console.log("clearing cache:", this.frameDataCache.length);
         this.frameCache = [];
         this.frameDataCache = [];
         this.cacheFrame = -1;


### PR DESCRIPTION
Problem
=======
Bugs with local playback:
* [Local playback - sometimes most of the frames in VisData cache disappear](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1428)
* [Local playback doesn't start at updated time after stepping frames](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1426)

Solution
========
Add 1 line of code to update `this.currentPlaybackFrameIndex` in `LocalSimulator.gotoRemoteSimulationTime()`

Thanks @toloudis !

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Pull this branch and link it to a local branch of simularium-website. Launch the dev server and try to repro the bugs mentioned above.