### PR TITLE
Fix/bugs in testbed slider

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -221,7 +221,8 @@ class Viewer extends React.Component<{}, ViewerState> {
 
     public handleTrajectoryInfo(data): void {
         console.log("Trajectory info arrived", data);
-        const totalDuration = data.totalSteps * data.timeStepSize;
+        // NOTE: Currently incorrectly assumes initial time of 0
+        const totalDuration = (data.totalSteps - 1) * data.timeStepSize;
         this.setState({
             totalDuration,
             timeStep: data.timeStepSize,
@@ -259,17 +260,11 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     public gotoNextFrame(): void {
-        const targetTime = parseFloat(
-            (this.state.currentTime + this.state.timeStep).toPrecision(4)
-        );
-        simulariumController.gotoTime(targetTime);
+        simulariumController.gotoTime(this.state.currentTime + this.state.timeStep);
     }
 
     public gotoPreviousFrame(): void {
-        const targetTime = parseFloat(
-            (this.state.currentTime - this.state.timeStep).toPrecision(4)
-        );
-        simulariumController.gotoTime(targetTime);
+        simulariumController.gotoTime(this.state.currentTime - this.state.timeStep);
     }
 
     private configureAndLoad() {

--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -367,6 +367,7 @@ class Viewer extends React.Component<{}, ViewerState> {
                     name="slider"
                     type="range"
                     min={0}
+                    step={this.state.timeStep}
                     value={this.state.currentTime}
                     max={this.state.totalDuration}
                     onChange={this.handleScrubTime}


### PR DESCRIPTION
Problem
=======
Resolves: [Slider in test viewer has problems](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1397)

The Jira ticket above has 3 issues:
1. The head (dot) doesn't accurately reflect the place in playback (for example, when there are 3 frames total and you're at the second frame, the dot should be in the middle but it's much farther ahead)
2. Towards the later frames of the simulation (second to the last frame?) the slider is stuck even if the viewer advances to the last frame
3. Why is there a + 1e-9 here? https://github.com/allen-cell-animated/simularium-viewer/blob/master/examples/Viewer.tsx#L268

Bug 3 has was resolved in a previous PR. **This PR fixes the remaining bugs 1 and 2.**


Solution
========
* Supplied a stepsize to the slider input to fix Bug 1.
* Fixed an off-by-1 error to fix Bug 2.
* Removed some old code (rounding to avoid floating point precision errors -- shouldn't be needed anymore after recent fixes using epsilon)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Test out the slider
