### PR TITLE
allow command or shift to be the key modifier for pan/rotate

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -483,7 +483,7 @@ class VisGeometry {
 
     public setPanningMode(pan: boolean): void {
         if (!pan) {
-            this.controls.enablePan = false;
+            this.controls.enablePan = true;
             this.controls.enableRotate = true;
             this.controls.mouseButtons = {
                 LEFT: MOUSE.ROTATE,
@@ -492,7 +492,7 @@ class VisGeometry {
             };
         } else {
             this.controls.enablePan = true;
-            this.controls.enableRotate = false;
+            this.controls.enableRotate = true;
             this.controls.mouseButtons = {
                 LEFT: MOUSE.PAN,
                 MIDDLE: MOUSE.DOLLY,
@@ -634,7 +634,7 @@ class VisGeometry {
         this.controls.maxDistance = 750;
         this.controls.minDistance = 5;
         this.controls.zoomSpeed = 1.0;
-        this.controls.enablePan = false;
+        this.setPanningMode(false);
         this.controls.saveState();
     }
 


### PR DESCRIPTION
Problem
=======
https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1390
Implement modifier keys.

Solution
========
Enabling both pan and rotate at the same time on orbitControls automatically uses ctrl or shift as modifier key

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

Change summary:
---------------
also a small initialization fix.  

Steps to Verify:
----------------
in pan mode, shift(or command/ctrl)+drag will rotate
in rotate mode, shift(or command/ctrl)+drag will pan

