### PR TITLE
Fix/file switching bugs

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -64,7 +64,6 @@ export default class SimulariumController {
     private networkEnabled: boolean;
     private isPaused: boolean;
     private fileChanged: boolean;
-    private canRequestNewTime: boolean;
     private playBackFile: string;
     // used to map geometry to agent types
     private geometryFile: string;
@@ -119,7 +118,6 @@ export default class SimulariumController {
         this.networkEnabled = true;
         this.isPaused = false;
         this.fileChanged = false;
-        this.canRequestNewTime = true;
         this.playBackFile = params.trajectoryPlaybackFile || "";
         this.geometryFile = this.resolveGeometryFile(
             params.trajectoryGeometryFile || "",
@@ -244,7 +242,8 @@ export default class SimulariumController {
     }
 
     public gotoTime(timeNs: number): void {
-        if (this.canRequestNewTime === false) return;
+        // If in the middle of changing files, ignore any gotoTime requests
+        if (this.fileChanged === true) return;
         if (this.visData.hasLocalCacheForTime(timeNs)) {
             this.visData.gotoTime(timeNs);
         } else {
@@ -293,7 +292,6 @@ export default class SimulariumController {
         assetPrefix?: string
     ): Promise<FileReturn> {
         this.fileChanged = true;
-        this.canRequestNewTime = false;
         this.playBackFile = newFileName;
         this.geometryFile = this.resolveGeometryFile(
             geometryFile || "",
@@ -336,7 +334,6 @@ export default class SimulariumController {
             return this.start()
                 .then(() => {
                     if (this.simulator) {
-                        this.canRequestNewTime = true;
                         this.simulator.requestSingleFrame(0);
                     }
                 })

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -64,6 +64,7 @@ export default class SimulariumController {
     private networkEnabled: boolean;
     private isPaused: boolean;
     private fileChanged: boolean;
+    private canRequestNewTime: boolean;
     private playBackFile: string;
     // used to map geometry to agent types
     private geometryFile: string;
@@ -118,6 +119,7 @@ export default class SimulariumController {
         this.networkEnabled = true;
         this.isPaused = false;
         this.fileChanged = false;
+        this.canRequestNewTime = true;
         this.playBackFile = params.trajectoryPlaybackFile || "";
         this.geometryFile = this.resolveGeometryFile(
             params.trajectoryGeometryFile || "",
@@ -242,6 +244,7 @@ export default class SimulariumController {
     }
 
     public gotoTime(timeNs: number): void {
+        if (this.canRequestNewTime === false) return;
         if (this.visData.hasLocalCacheForTime(timeNs)) {
             this.visData.gotoTime(timeNs);
         } else {
@@ -290,6 +293,7 @@ export default class SimulariumController {
         assetPrefix?: string
     ): Promise<FileReturn> {
         this.fileChanged = true;
+        this.canRequestNewTime = false;
         this.playBackFile = newFileName;
         this.geometryFile = this.resolveGeometryFile(
             geometryFile || "",
@@ -332,6 +336,7 @@ export default class SimulariumController {
             return this.start()
                 .then(() => {
                     if (this.simulator) {
+                        this.canRequestNewTime = true;
                         this.simulator.requestSingleFrame(0);
                     }
                 })

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -63,7 +63,7 @@ export default class SimulariumController {
 
     private networkEnabled: boolean;
     private isPaused: boolean;
-    private fileChanged: boolean;
+    private isFileChanging: boolean;
     private playBackFile: string;
     // used to map geometry to agent types
     private geometryFile: string;
@@ -117,7 +117,7 @@ export default class SimulariumController {
 
         this.networkEnabled = true;
         this.isPaused = false;
-        this.fileChanged = false;
+        this.isFileChanging = false;
         this.playBackFile = params.trajectoryPlaybackFile || "";
         this.geometryFile = this.resolveGeometryFile(
             params.trajectoryGeometryFile || "",
@@ -179,8 +179,8 @@ export default class SimulariumController {
         this.createSimulatorConnection(config);
     }
 
-    public get hasChangedFile(): boolean {
-        return this.fileChanged;
+    public get isChangingFile(): boolean {
+        return this.isFileChanging;
     }
 
     public connect(): Promise<string> {
@@ -243,7 +243,7 @@ export default class SimulariumController {
 
     public gotoTime(timeNs: number): void {
         // If in the middle of changing files, ignore any gotoTime requests
-        if (this.fileChanged === true) return;
+        if (this.isFileChanging === true) return;
         if (this.visData.hasLocalCacheForTime(timeNs)) {
             this.visData.gotoTime(timeNs);
         } else {
@@ -270,7 +270,7 @@ export default class SimulariumController {
     }
 
     public clearFile(): void {
-        this.fileChanged = false;
+        this.isFileChanging = false;
         this.playBackFile = "";
         this.geometryFile = "";
         this.assetPrefix = DEFAULT_ASSET_PREFIX;
@@ -291,7 +291,7 @@ export default class SimulariumController {
         geometryFile?: string,
         assetPrefix?: string
     ): Promise<FileReturn> {
-        this.fileChanged = true;
+        this.isFileChanging = true;
         this.playBackFile = newFileName;
         this.geometryFile = this.resolveGeometryFile(
             geometryFile || "",
@@ -348,7 +348,7 @@ export default class SimulariumController {
     }
 
     public markFileChangeAsHandled(): void {
-        this.fileChanged = false;
+        this.isFileChanging = false;
     }
 
     public getFile(): string {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -581,7 +581,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         const elapsedTime = now - this.lastRenderTime;
         const totalElapsedTime = now - this.startTime;
         if (elapsedTime > timePerFrame) {
-            if (simulariumController.hasChangedFile) {
+            if (simulariumController.isChangingFile) {
                 this.visGeometry.clearForNewTrajectory();
                 const p = this.visGeometry.mapFromJSON(
                     simulariumController.getFile(),


### PR DESCRIPTION
Problem
=======
Closes #126
Closes #127 

Solution
========
### Short explanation: 
Prevent `simulariumController.gotoTime` from requesting a new time when the viewer is in the middle of changing files.

### Long explanation: 

The Antd Slider component's `componentDidUpdate` method is fired for some reason (probably because its parent's props change, but regardless of the reason, I don't think I have control over it?) when we're switching files but when we haven't finished loading the new file. And when that method fires, it triggers its `onChange` handler which eventually calls `simulariumController.gotoTime(arg)`, with the `arg` being the time that the slider was displaying for the trajectory we're trying to change out. This all leads to time data from the old trajectory file coming into and mixing with the cache of the new trajectory file and interfering with the determination of the new file's `firstFrameTime` and `lastFrameTime` among other things. 

`simulariumController` already has a boolean property called `fileChanged` that becomes `true` for the duration of a file change (loading period). If we disable `simulariumController.gotoTime()` when a file is still loading then we can prevent unwanted new time requests/messages during the file change period. This seems to fix the above two issues.

I think that the reason these bugs came up after [this simularium-website commit](https://github.com/allen-cell-animated/simularium-website/pull/129) is because the rounding of time values we were doing previously were simply masking some issues. 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch and link your local viewer to a locally running simularium-website
2. Try to reproduce the bugs above, and also check that you can switch files without problem in general