### PR TITLE
Fix/skip frame bugs (temporary fix)

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -234,7 +234,7 @@ class Viewer extends React.Component<{}, ViewerState> {
     }
 
     public handleScrubTime(event): void {
-        simulariumController.gotoTime(event.target.value);
+        simulariumController.gotoTime(parseFloat(event.target.value));
     }
 
     public handleUIDisplayData(uiDisplayData: UIDisplayData): void {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -252,7 +252,7 @@ export default class SimulariumController {
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
 
-                // This arbitrary rounding of timeNs is a temporary fix until
+                // NOTE: This arbitrary rounding of timeNs is a temporary fix until
                 // simularium-engine is updated to work with imprecise float time values.
                 // Revert the 2 lines of code below to:
                 // this.simulator.gotoRemoteSimulationTime(timeNs);

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -251,7 +251,8 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
-                this.simulator.gotoRemoteSimulationTime(timeNs);
+                const roundedTime = parseFloat(timeNs.toPrecision(4));
+                this.simulator.gotoRemoteSimulationTime(roundedTime);
             }
         }
     }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -251,6 +251,11 @@ export default class SimulariumController {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
+
+                // This arbitrary rounding of timeNs is a temporary fix until
+                // simularium-engine is updated to work with imprecise float time values.
+                // Revert the 2 lines of code below to:
+                // this.simulator.gotoRemoteSimulationTime(timeNs);
                 const roundedTime = parseFloat(timeNs.toPrecision(4));
                 this.simulator.gotoRemoteSimulationTime(roundedTime);
             }


### PR DESCRIPTION
Problem
=======
At least 2 known bugs associated with the skip frame button: #129, #130 

The bugs above appeared (albeit not noticed right away) when [this commit](https://github.com/allen-cell-animated/simularium-website/pull/129) was merged to simularium-website. Prior to this merge, the front end was rounding all time values to an arbitrary number of significant figures before requesting a frame with a specific time from the back end. Since the merge, the front end has been sending unrounded, imprecise time values to the back end when requesting a frame at a specific time -- like 10.499999999991234 or 10.5000000000153, when the desired time is 10.5 seconds. This works fine when the actual desired time is less than the requested time (as in the case of 10.5000000000153), but when the desired time is slightly greater than the requested time (as in the case of 10.499999999991234), the back end sends a frame at 10.4 seconds instead of 10.5. 

Solution
========
I think the real fix for this problem is to update the simularium-engine to return the frame that has the timestamp closest to the requested time, instead of returning the frame with the timestamp closest to _and_ less than the requested time. However we're currently blocked on that task, so as a temporary fix, this PR proposes bringing back the arbitrary rounding of time values that simularium-website used to do before (see the old version of line 303 in simularium-website/src/containers/ViewerPanel/index.tsx [here](https://github.com/allen-cell-animated/simularium-website/pull/129/files)), but in simularium-viewer instead (immediately before a websocket request is made).


## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. Pull this branch and `npm start`
2. Launch the viewer testbed and check that the bugs above aren't reproducible anymore
3. Install this branch as a dependency for a local copy of simularium-website and check that the bugs aren't reproducible in the simularium-website dev environment either.
