### PR TITLE
Rename timeNs as time

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -241,29 +241,29 @@ export default class SimulariumController {
         }
     }
 
-    public gotoTime(timeNs: number): void {
+    public gotoTime(time: number): void {
         // If in the middle of changing files, ignore any gotoTime requests
         if (this.isFileChanging === true) return;
-        if (this.visData.hasLocalCacheForTime(timeNs)) {
-            this.visData.gotoTime(timeNs);
+        if (this.visData.hasLocalCacheForTime(time)) {
+            this.visData.gotoTime(time);
         } else {
             if (this.networkEnabled && this.simulator) {
                 // else reset the local cache,
                 //  and play remotely from the desired simulation time
                 this.visData.clearCache();
 
-                // NOTE: This arbitrary rounding of timeNs is a temporary fix until
+                // NOTE: This arbitrary rounding of time is a temporary fix until
                 // simularium-engine is updated to work with imprecise float time values.
                 // Revert the 2 lines of code below to:
-                // this.simulator.gotoRemoteSimulationTime(timeNs);
-                const roundedTime = parseFloat(timeNs.toPrecision(4));
+                // this.simulator.gotoRemoteSimulationTime(time);
+                const roundedTime = parseFloat(time.toPrecision(4));
                 this.simulator.gotoRemoteSimulationTime(roundedTime);
             }
         }
     }
 
-    public playFromTime(timeNs: number): void {
-        this.gotoTime(timeNs);
+    public playFromTime(time: number): void {
+        this.gotoTime(time);
         this.isPaused = false;
     }
 

--- a/src/simularium/ClientSimulator.ts
+++ b/src/simularium/ClientSimulator.ts
@@ -269,11 +269,11 @@ export class ClientSimulator implements ISimulator {
         );
     }
 
-    public gotoRemoteSimulationTime(timeNanoSeconds: number): void {
+    public gotoRemoteSimulationTime(time: number): void {
         this.sendSimulationRequest(
             {
                 msgType: ClientMessageEnum.ID_GOTO_SIMULATION_TIME,
-                time: timeNanoSeconds,
+                time: time,
             },
             "Load single frame at specified Time"
         );

--- a/src/simularium/ISimulator.ts
+++ b/src/simularium/ISimulator.ts
@@ -55,7 +55,7 @@ export interface ISimulator {
 
     requestSingleFrame(startFrameNumber: number): void;
 
-    gotoRemoteSimulationTime(timeNanoSeconds: number): void;
+    gotoRemoteSimulationTime(time: number): void;
 
     requestTrajectoryFileInfo(fileName: string): void;
 }

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -158,13 +158,13 @@ export class LocalFileSimulator implements ISimulator {
         this.onTrajectoryDataArrive(this.getFrame(startFrameNumber));
     }
 
-    public gotoRemoteSimulationTime(timeNs: number): void {
+    public gotoRemoteSimulationTime(time: number): void {
         const { bundleData } = this.simulariumFile.spatialData;
         const { timeStepSize } = this.simulariumFile.trajectoryInfo;
 
         // Find the index of the frame that has the time matching our target time
         const frameNumber = bundleData.findIndex((bundleData) => {
-            return compareTimes(bundleData.time, timeNs, timeStepSize) === 0;
+            return compareTimes(bundleData.time, time, timeStepSize) === 0;
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -453,11 +453,11 @@ export class RemoteSimulator implements ISimulator {
         );
     }
 
-    public gotoRemoteSimulationTime(timeNanoSeconds: number): void {
+    public gotoRemoteSimulationTime(time: number): void {
         this.sendWebSocketRequest(
             {
                 msgType: NetMessageEnum.ID_GOTO_SIMULATION_TIME,
-                time: timeNanoSeconds,
+                time: time,
             },
             "Load single frame at specified Time"
         );

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -375,7 +375,7 @@ class VisData {
     /**
      *   Functions to check update
      * */
-    public hasLocalCacheForTime(timeNs: number): boolean {
+    public hasLocalCacheForTime(time: number): boolean {
         if (this.frameDataCache.length < 1) {
             return false;
         }
@@ -386,20 +386,18 @@ class VisData {
         ].time;
 
         const notLessThanFirstFrameTime =
-            compareTimes(timeNs, firstFrameTime, this.timeStepSize) !== -1;
+            compareTimes(time, firstFrameTime, this.timeStepSize) !== -1;
         const notGreaterThanLastFrameTime =
-            compareTimes(timeNs, lastFrameTime, this.timeStepSize) !== 1;
+            compareTimes(time, lastFrameTime, this.timeStepSize) !== 1;
         return notLessThanFirstFrameTime && notGreaterThanLastFrameTime;
     }
 
-    public gotoTime(timeNs: number): void {
+    public gotoTime(time: number): void {
         this.cacheFrame = -1;
 
         // Find the index of the frame that has the time matching our target time
         const frameNumber = this.frameDataCache.findIndex((frameData) => {
-            return (
-                compareTimes(frameData.time, timeNs, this.timeStepSize) === 0
-            );
+            return compareTimes(frameData.time, time, this.timeStepSize) === 0;
         });
 
         // frameNumber is -1 if findIndex() above doesn't find a match

--- a/src/simularium/mock/DummyRemoteSimulator.ts
+++ b/src/simularium/mock/DummyRemoteSimulator.ts
@@ -164,9 +164,9 @@ export class DummyRemoteSimulator extends RemoteSimulator {
         }, this.commandLatencyMS);
     }
 
-    public gotoRemoteSimulationTime(timeNS: number): void {
+    public gotoRemoteSimulationTime(time: number): void {
         setTimeout(() => {
-            this.frameCounter = timeNS / this.timeStep;
+            this.frameCounter = time / this.timeStep;
 
             const msg = this.getDataBundle(this.frameCounter, 1);
             this.frameCounter++;


### PR DESCRIPTION
Problem
=======
We have outdated variable names `timeNs`, `timeNS`, and `timeNanoseconds` which are confusing because time is not in ns by default anymore.

Resolves: [Rename all instances of timeNs in simularium-viewer](https://aicsjira.corp.alleninstitute.org/browse/AGENTVIZ-1427)

Solution
========
Renamed all occurrences of the above variable names as `time`

## Type of change
Please delete options that are not relevant.

* Variable renaming to enhance mental well-being

Steps to Verify:
----------------
1. Pull this branch, `npm start` and make sure the basic functions still work as before on the viewer testbed
