### PR TITLE
Fix/zoom while pan

### DIFF
--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -466,6 +466,7 @@ class VisGeometry {
     public zoomIn(): void {
         const position = this.camera.position.clone();
         const target = this.controls.target.clone();
+        console.log(target);
         const distance = position.distanceTo(target);
         const newDistance = distance - CAMERA_DOLLY_STEP_SIZE;
         const newPosition = new Vector3()
@@ -474,7 +475,9 @@ class VisGeometry {
         if (newDistance <= this.controls.minDistance) {
             return;
         }
-        this.camera.position.copy(newPosition);
+        this.camera.position.copy(
+            new Vector3().addVectors(newPosition, target)
+        );
     }
 
     public zoomOut(): void {
@@ -488,7 +491,9 @@ class VisGeometry {
         if (newDistance >= this.controls.maxDistance) {
             return;
         }
-        this.camera.position.copy(newPosition);
+        this.camera.position.copy(
+            new Vector3().addVectors(newPosition, target)
+        );
     }
 
     public setPanningMode(pan: boolean): void {

--- a/src/simularium/VisGeometry.ts
+++ b/src/simularium/VisGeometry.ts
@@ -463,37 +463,33 @@ class VisGeometry {
         this.rotateDistance = this.camera.position.distanceTo(new Vector3());
     }
 
-    public zoomIn(): void {
+    private dolly(changeBy: number): void {
         const position = this.camera.position.clone();
         const target = this.controls.target.clone();
-        console.log(target);
         const distance = position.distanceTo(target);
-        const newDistance = distance - CAMERA_DOLLY_STEP_SIZE;
+        const newDistance = distance + changeBy;
+        if (
+            newDistance <= this.controls.minDistance ||
+            newDistance >= this.controls.maxDistance
+        ) {
+            return;
+        }
         const newPosition = new Vector3()
             .subVectors(position, target)
             .setLength(newDistance);
-        if (newDistance <= this.controls.minDistance) {
-            return;
-        }
         this.camera.position.copy(
             new Vector3().addVectors(newPosition, target)
         );
     }
 
+    public zoomIn(): void {
+        const changeBy = -CAMERA_DOLLY_STEP_SIZE;
+        this.dolly(changeBy);
+    }
+
     public zoomOut(): void {
-        const position = this.camera.position.clone();
-        const target = this.controls.target.clone();
-        const distance = position.distanceTo(target);
-        const newDistance = distance + CAMERA_DOLLY_STEP_SIZE;
-        const newPosition = new Vector3()
-            .subVectors(position, target)
-            .setLength(newDistance);
-        if (newDistance >= this.controls.maxDistance) {
-            return;
-        }
-        this.camera.position.copy(
-            new Vector3().addVectors(newPosition, target)
-        );
+        const changeBy = CAMERA_DOLLY_STEP_SIZE;
+        this.dolly(changeBy);
     }
 
     public setPanningMode(pan: boolean): void {


### PR DESCRIPTION
Problem
=======
When you had panned off of center and then clicked the zoom buttons, the camera would rotate weirdly. 
resolves #125 

Solution
========
The camera position was not being set to the correct vector in world space. We had calculated the vector that was the correct length, and the correct orientation, and as long as the target was 0,0,0 that was enough. But once we pan, the vector needed to be added to the new target position, which was no longer 0,0,0

with @toloudis 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Change summary:
---------------
* changed the new camera position to the target vector + the vector that represents the new distance from the target
* I also combined the two functions into one dolly function that just takes the change by scalar as an argument

Steps to Verify:
----------------
1. npm start
2. load a model
3. switch to pan mode, pan off center
4. click the (+) and (-) buttons
5. should zoom in and out the same as scrolling your mouse does

