### PR TITLE
Change references to master branch to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,14 +24,14 @@ ___
 1. Fork the repo on GitHub.
 2. Create a branch and make your edits on your branch, pushing back to your fork.
 3. Make sure `npm run typeCheck`, `npm run test` and `npm run lint` all exit without errors. Add tests and documentation as needed.
-4. Submit a pull request back to master via GitHub using template, include screen shots for visual changes. 
+4. Submit a pull request back to main via GitHub using template, include screen shots for visual changes. 
 
 ___
 
 ## Publishing
 
 1. Make a new version: `npm version [patch/minor/major]` -- this will give you the new tag, e.g., `2.7.1`
-2. Push the new package.json version: `git push origin master`
+2. Push the new package.json version: `git push origin main`
 3. Push the new tag: `git push origin v[NEW_TAG]` -- e.g. `git push origin v2.7.1`
 
 ___

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ https://www.npmjs.com/package/@aics/simularium-viewer
 ---
 
 ## Description
-This viewer can visualize trajectories that are in Simularium format (see the file format documentation [here](https://github.com/allen-cell-animated/simulariumio/blob/master/file_format.md)). The viewer can operate in the following modes:
+This viewer can visualize trajectories that are in Simularium format (see the file format documentation [here](https://github.com/allen-cell-animated/simulariumio/blob/main/file_format.md)). The viewer can operate in the following modes:
 
 **drag-and-drop**  
 Drag a Simularium file into the window (WebGL) area of the viewer.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "processCSS": "postcss src/viewport/index.css --output style/style.css",
         "build": "npm-run-all generateTypes bundle transpileES transpileCommonJs processCSS",
         "publish-patch": "npm version patch | xargs -I {} sh -c 'git push origin {}'",
-        "postpublish-patch": "git push origin master"
+        "postpublish-patch": "git push origin main"
     },
     "files": [
         "es",


### PR DESCRIPTION
Problem
=======
I changed the master branch for simularium-website, viewer, and simulariumio to `main` but there are references to `master` in this repo.

Solution
========
I replaced all the references to the master branch (of this repo and to simulariumio's) in this repository.

FYI, all URLs to a repo's master branch (like https://github.com/allen-cell-animated/simulariumio/blob/master/examples/Tutorial_custom.ipynb) automatically redirect to the main branch, so it's not a worry. But I swapped them out in _README.md_ anyway because why not.

Steps to Verify:
----------------
1. Pull this branch and do a global search for `master` and verify that all the occurrences that need updating to `main` are updated. (There shouldn't be any left)

