### PR TITLE
fix bug during trajectory changes

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -290,6 +290,7 @@ export default class SimulariumController {
         this.assetPrefix = assetPrefix ? assetPrefix : DEFAULT_ASSET_PREFIX;
         this.visData.WaitForFrame(0);
         this.visData.clearCache();
+        this.visData.cancelAllWorkers();
 
         this.stop();
 

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -346,10 +346,9 @@ class VisData {
     }
 
     public constructor() {
+        this.webWorker = null;
         if (util.ThreadUtil.browserSupportsWebWorkers()) {
             this.setupWebWorker();
-        } else {
-            this.webWorker = null;
         }
         this.frameCache = [];
         this.frameDataCache = [];

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -384,8 +384,9 @@ class VisData {
         }
 
         const firstFrameTime = this.frameDataCache[0].time;
-        const lastFrameTime =
-            this.frameDataCache[this.frameDataCache.length - 1].time;
+        const lastFrameTime = this.frameDataCache[
+            this.frameDataCache.length - 1
+        ].time;
 
         const notLessThanFirstFrameTime =
             compareTimes(time, firstFrameTime, this.timeStepSize) !== -1;


### PR DESCRIPTION
Problem
=======
Fix #163 
When playing back a trajectory that receives data faster than it can queue and process it in the webworker, and then changing trajectory, the webworker was continuing to submit data from the old trajectory.  This was observed with the ClientSimulators returning data in the old raw json format.  I'm not sure if this can happen with drag-n-drop also but might be related to https://github.com/allen-cell-animated/simularium-website/issues/160

Solution
========
Terminate and restart webworker when trajectory changes

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Can do repro steps in the original bug before and after this change.

