### PR TITLE
Fix/camera controls break in simularium-website

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -108,6 +108,14 @@ export default class SimulariumController {
             this.playBackFile
         );
         this.assetPrefix = params.assetLocation || DEFAULT_ASSET_PREFIX;
+
+        this.zoomIn = this.zoomIn.bind(this);
+        this.zoomOut = this.zoomOut.bind(this);
+        this.resetCamera = this.resetCamera.bind(this);
+        this.centerCamera = this.centerCamera.bind(this);
+        this.reOrientCamera = this.reOrientCamera.bind(this);
+        this.setPanningMode = this.setPanningMode.bind(this);
+        this.setFocusMode = this.setFocusMode.bind(this);
     }
 
     private resolveGeometryFile(
@@ -424,6 +432,7 @@ export default class SimulariumController {
     }
 
     public setPanningMode(pan: boolean): void {
+        console.log("THIS:", this);
         if (this.visGeometry) {
             this.visGeometry.setPanningMode(pan);
         }

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -432,7 +432,6 @@ export default class SimulariumController {
     }
 
     public setPanningMode(pan: boolean): void {
-        console.log("THIS:", this);
         if (this.visGeometry) {
             this.visGeometry.setPanningMode(pan);
         }


### PR DESCRIPTION
Problem
=======
When running the `main` branch of simularium-viewer inside simularium-website, the viewer wouldn't mount and would display these errors:

![image](https://user-images.githubusercontent.com/12690133/130709350-f5fe663c-5436-4225-83ac-e49ffaa4dcdb.png)

Whenever `setFocusMode` or other camera control methods from `SimulariumController` was being called from a component in simularium-website, `this` would be undefined when it should be an instance of `SimulariumController`.

This most likely started happening after #136 was merged.

Solution
========
Bind the `this` in each camera control method to `SimulariumController`

Thanks @meganrm for pair programming :) 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
Install this branch of simularium-viewer in simularium-website and load a model. The model should load without problem and the camera controls should work without problem.
