### PR TITLE
Feature/warn if server connection becomes invalid

### DIFF
--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -264,6 +264,11 @@ export default class SimulariumController {
     ): Promise<FileReturn> {
         this.isFileChanging = true;
         this.playBackFile = newFileName;
+
+        if (this.simulator instanceof RemoteSimulator) {
+            this.simulator.handleError = () => noop;
+        }
+
         this.visData.WaitForFrame(0);
         this.visData.clearCache();
         this.visData.cancelAllWorkers();

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -107,7 +107,6 @@ export default class SimulariumController {
         this.setPanningMode = this.setPanningMode.bind(this);
         this.setFocusMode = this.setFocusMode.bind(this);
     }
-    
 
     private createSimulatorConnection(
         netConnectionConfig?: NetConnectionParams,
@@ -122,7 +121,10 @@ export default class SimulariumController {
                 localFile
             );
         } else if (netConnectionConfig) {
-            this.simulator = new RemoteSimulator(netConnectionConfig);
+            this.simulator = new RemoteSimulator(
+                netConnectionConfig,
+                this.onError
+            );
         } else {
             throw new Error(
                 "Insufficient data to determine and configure simulator connection"

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -76,14 +76,23 @@ export class RemoteSimulator implements ISimulator {
     protected lastRequestedFile: string;
     public connectionTimeWaited: number;
     public connectionRetries: number;
+    public onError: (errorMessage: string) => void | (() => void);
 
-    public constructor(opts?: NetConnectionParams) {
+    public constructor(
+        opts?: NetConnectionParams,
+        errorHandler?: (error: string) => void
+    ) {
         this.webSocket = null;
         this.serverIp = opts && opts.serverIp ? opts.serverIp : "localhost";
         this.serverPort = opts && opts.serverPort ? opts.serverPort : 9002;
         this.connectionTimeWaited = 0;
         this.connectionRetries = 0;
         this.lastRequestedFile = "";
+        this.onError =
+            errorHandler ||
+            (() => {
+                /* do nothing */
+            });
 
         this.logger = jsLogger.get("netconnection");
         this.logger.setLevel(jsLogger.DEBUG);
@@ -331,10 +340,16 @@ export class RemoteSimulator implements ISimulator {
     }
 
     private sendWebSocketRequest(jsonData, requestDescription: string): void {
-        if (this.webSocket !== null) {
-            this.webSocket.send(JSON.stringify(jsonData));
-        }
-        this.logWebSocketRequest(requestDescription, jsonData);
+        // if (!this.socketIsValid()) {
+        console.error("Connection to server was closed unexpectedly.");
+        this.onError(
+            "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
+        );
+        // }
+        // if (this.webSocket !== null) {
+        //     this.webSocket.send(JSON.stringify(jsonData));
+        // }
+        // this.logWebSocketRequest(requestDescription, jsonData);
     }
 
     /**

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -340,16 +340,17 @@ export class RemoteSimulator implements ISimulator {
     }
 
     private sendWebSocketRequest(jsonData, requestDescription: string): void {
-        if (!this.socketIsValid()) {
+        if (this.socketIsValid()) {
+            if (this.webSocket !== null) {
+                this.webSocket.send(JSON.stringify(jsonData));
+            }
+            this.logWebSocketRequest(requestDescription, jsonData);
+        } else {
             console.error("Connection to server was closed unexpectedly.");
             this.handleError(
                 "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
             );
         }
-        if (this.webSocket !== null) {
-            this.webSocket.send(JSON.stringify(jsonData));
-        }
-        this.logWebSocketRequest(requestDescription, jsonData);
     }
 
     /**

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -346,9 +346,11 @@ export class RemoteSimulator implements ISimulator {
             }
             this.logWebSocketRequest(requestDescription, jsonData);
         } else {
-            console.error("Connection to server was closed unexpectedly.");
+            console.error(
+                "Request to server cannot be made with a closed Websocket connection."
+            );
             this.handleError(
-                "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
+                "Connection to server is closed; please try reloading. If the problem persists, the server may be too busy. Please try again at another time."
             );
         }
     }

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -76,7 +76,7 @@ export class RemoteSimulator implements ISimulator {
     protected lastRequestedFile: string;
     public connectionTimeWaited: number;
     public connectionRetries: number;
-    public onError: (errorMessage: string) => void | (() => void);
+    public handleError: (errorMessage: string) => void | (() => void);
 
     public constructor(
         opts?: NetConnectionParams,
@@ -88,7 +88,7 @@ export class RemoteSimulator implements ISimulator {
         this.connectionTimeWaited = 0;
         this.connectionRetries = 0;
         this.lastRequestedFile = "";
-        this.onError =
+        this.handleError =
             errorHandler ||
             (() => {
                 /* do nothing */
@@ -342,7 +342,7 @@ export class RemoteSimulator implements ISimulator {
     private sendWebSocketRequest(jsonData, requestDescription: string): void {
         if (!this.socketIsValid()) {
             console.error("Connection to server was closed unexpectedly.");
-            this.onError(
+            this.handleError(
                 "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
             );
         }

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -357,10 +357,6 @@ export class RemoteSimulator implements ISimulator {
      * Websocket Update Parameters
      */
     public sendTimeStepUpdate(newTimeStep: number): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
-
         const jsonData = {
             msgType: NetMessageEnum.ID_UPDATE_TIME_STEP,
             timeStep: newTimeStep,
@@ -369,10 +365,6 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public sendParameterUpdate(paramName: string, paramValue: number): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
-
         const jsonData = {
             msgType: NetMessageEnum.ID_UPDATE_RATE_PARAM,
             paramName: paramName,
@@ -382,10 +374,6 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public sendModelDefinition(model: string): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
-
         const dataToSend = {
             model: model,
             msgType: NetMessageEnum.ID_MODEL_DEFINITION,

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -449,9 +449,6 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public pauseRemoteSim(): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
         this.sendWebSocketRequest(
             { msgType: NetMessageEnum.ID_VIS_DATA_PAUSE },
             "Pause Simulation"
@@ -459,9 +456,6 @@ export class RemoteSimulator implements ISimulator {
     }
 
     public resumeRemoteSim(): void {
-        if (!this.socketIsValid()) {
-            return;
-        }
         this.sendWebSocketRequest(
             { msgType: NetMessageEnum.ID_VIS_DATA_RESUME },
             "Resume Simulation"

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -340,16 +340,16 @@ export class RemoteSimulator implements ISimulator {
     }
 
     private sendWebSocketRequest(jsonData, requestDescription: string): void {
-        // if (!this.socketIsValid()) {
-        console.error("Connection to server was closed unexpectedly.");
-        this.onError(
-            "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
-        );
-        // }
-        // if (this.webSocket !== null) {
-        //     this.webSocket.send(JSON.stringify(jsonData));
-        // }
-        // this.logWebSocketRequest(requestDescription, jsonData);
+        if (!this.socketIsValid()) {
+            console.error("Connection to server was closed unexpectedly.");
+            this.onError(
+                "Connection to server was closed unexpectedly. Try reloading. If the problem persists, the server may be too busy. Please try again at another time."
+            );
+        }
+        if (this.webSocket !== null) {
+            this.webSocket.send(JSON.stringify(jsonData));
+        }
+        this.logWebSocketRequest(requestDescription, jsonData);
     }
 
     /**


### PR DESCRIPTION
Problem
=======
Closes #171 

Solution
========
This is the solution I arrived at that doesn't require hunting down all the calls in the SimulariumController that trigger a websocket request and catching individual errors. I sort of copied [how errors in VisGeometry are propagated up](https://github.com/allen-cell-animated/simularium-viewer/blob/main/src/viewport/index.tsx#L196) -- I gave RemoteSimulator a `handleError` method that's supplied by SimulariumController (`onError`), which is originally supplied by simularium-website and displays the error as a notification to the user. 

(If the invalid socket detection happened at the controller level, @toloudis is correct ([comment on issue](https://github.com/allen-cell-animated/simularium-viewer/issues/171#issuecomment-906058568)), the error handling/propagation is already done. But the invalid socket detection happens in RemoteSimulator, not the controller, so the above change needed to happen.)

Then at the beginning of every websocket request made by RemoteSimulator, we check if the connection is still valid, and if not valid (websocket is in closed state), we call the `handleError` method and pass it the appropriate error message (alternative suggestions to error message text welcome).

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)

Steps to Verify:
----------------
1. Pull this branch
1. Comment out everything but lines 349-352 in `RemoteSimulator.sendWebSocketRequest` (so that the error fires regardless of actual socket state)
2. Symlink the branch to simularium-website and run simularium-website
3. Load a networked model. The model won't load successfully, and you should see the error message displayed as a notification as shown in the screenshot below.

Screenshots (optional):
-----------------------
![image](https://user-images.githubusercontent.com/12690133/131039410-9bab431b-5040-4e5b-9e33-03089ff6d47e.png)
