### PR TITLE
Feature/user colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2912,9 +2912,9 @@
             "dev": true
         },
         "@types/lodash": {
-            "version": "4.14.172",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
-            "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+            "version": "4.14.175",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+            "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
             "dev": true
         },
         "@types/minimatch": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "~7.14.5",
         "@types/jest": "^27.0.1",
-        "@types/lodash": "^4.14.168",
+        "@types/lodash": "^4.14.175",
         "@types/react": "^16.14.3",
         "@typescript-eslint/eslint-plugin": "~4.29.0",
         "@typescript-eslint/parser": "~4.29.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "lint": "eslint src/**/*.ts src/**/*.tsx",
         "test": "jest src/**/*.test.ts --coverage",
         "typeCheck": "tsc -p tsconfig.json --noEmit",
+        "all-checks": "npm-run-all lint test typeCheck",
         "generateTypes": "tsc -p tsconfig.base.json --emitDeclarationOnly",
         "bundle": "BABEL_ENV=es NODE_ENV=production webpack --config webpack.config.js",
         "transpileES": "TS_NODE_PROJECT=tsconfig.es.json BABEL_ENV=es babel src --out-dir es --extensions .ts,.tsx --ignore src/**/*.test.ts",

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -21,6 +21,7 @@ export interface SelectionStateInfo {
 interface DisplayStateEntry {
     name: string;
     id: string;
+    color: string;
 }
 
 interface UIDisplayEntry {
@@ -101,6 +102,18 @@ class SelectionInterface {
         this.entries[name].push(entry);
     }
 
+    public getUnmodifiedStateId(name: string): number {
+        const entryList = this.entries[name];
+        if (!entryList) {
+            null;
+        }
+
+        const unmodified = entryList.find((entry: DecodedTypeEntry) => {
+            return entry.tags.length === 0;
+        });
+        return unmodified ? unmodified.id : null;
+    }
+
     public getColorsForName(name: string): string[] {
         const entryList = this.entries[name];
         const colors: string[] = [];
@@ -112,7 +125,6 @@ class SelectionInterface {
                 colors.push(entry.color);
             }
         });
-
         return colors;
     }
 

--- a/src/simularium/VisGeometry/GeometryStore.ts
+++ b/src/simularium/VisGeometry/GeometryStore.ts
@@ -350,11 +350,10 @@ class GeometryStore {
          * If Promise caches, the geometry is replaced with a sphere
          * and the user is notified.
          */
-        const { displayType, color, url } = agentVisData;
+        const { displayType, url } = agentVisData;
         this.mlogger.debug(`Geo for id ${id} set to '${url}'`);
         const isMesh = displayType === GeometryDisplayType.OBJ;
         const isPDB = displayType === GeometryDisplayType.PDB;
-        console.log(color); // TODO: handle color
         if (!url) {
             // displayType not either pdb or obj, will show a sphere
             // TODO: handle CUBE, GIZMO etc

--- a/src/simularium/VisGeometry/index.ts
+++ b/src/simularium/VisGeometry/index.ts
@@ -930,7 +930,7 @@ class VisGeometry {
 
     public setColorForIds(ids: number[], colorId: number): void {
         /**
-         * Sets one color for a set if ids, using an index into a color array
+         * Sets one color for a set of ids, using an index into a color array
          * @param ids agent ids that should all have the same color
          * @param colorId index into the color array
          */

--- a/src/simularium/VisGeometry/index.ts
+++ b/src/simularium/VisGeometry/index.ts
@@ -910,21 +910,37 @@ class VisGeometry {
         return this.getColorForIndex(index);
     }
 
+    public setColorForId(id: number, colorId: number): void {
+        /**
+         * @param id agent id
+         * @param colorId index into the color array
+         */
+        if (this.isIdColorMappingSet) {
+            throw new FrontEndError(
+                "Attempted to set agent-color after color mapping was finalized"
+            );
+        }
+        this.idColorMapping.set(id, colorId);
+
+        // if we don't have a mesh for this, add a sphere instance to mesh registry?
+        if (!this.visGeomMap.has(id)) {
+            this.visGeomMap.set(id, DEFAULT_MESH_NAME);
+        }
+    }
+
     public setColorForIds(ids: number[], colorId: number): void {
+        /**
+         * Sets one color for a set if ids, using an index into a color array
+         * @param ids agent ids that should all have the same color
+         * @param colorId index into the color array
+         */
         if (this.isIdColorMappingSet) {
             throw new FrontEndError(
                 "Attempted to set agent-color after color mapping was finalized"
             );
         }
 
-        ids.forEach((id) => {
-            this.idColorMapping.set(id, colorId);
-
-            // if we don't have a mesh for this, add a sphere instance to mesh registry?
-            if (!this.visGeomMap.has(id)) {
-                this.visGeomMap.set(id, DEFAULT_MESH_NAME);
-            }
-        });
+        ids.forEach((id) => this.setColorForId(id, colorId));
     }
 
     public getColorForIndex(index: number): Color {

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -16,13 +16,14 @@ const idMapping = {
     12: { name: "D" },
     13: { name: "E#t1000" },
 };
+const color = "";
 
 describe("SelectionInterface module", () => {
     describe("Handles Input", () => {
         test("Can decode valid encoded input", () => {
             const input = "name#tag1_tag2";
             const si = new SelectionInterface();
-            si.decode(input);
+            si.decode(input, color);
 
             expect(si.containsName("name"));
             expect(si.containsTag("tag1"));
@@ -32,7 +33,7 @@ describe("SelectionInterface module", () => {
         test("Can decode valid untagged input", () => {
             const input = "name";
             const si = new SelectionInterface();
-            si.decode(input);
+            si.decode(input, color);
 
             expect(si.containsName("name"));
         });
@@ -41,7 +42,7 @@ describe("SelectionInterface module", () => {
             const input = "#no_name";
             const si = new SelectionInterface();
             expect(() => {
-                si.decode(input);
+                si.decode(input, color);
             }).toThrowError();
         });
     });

--- a/src/test/SelectionInterface.test.ts
+++ b/src/test/SelectionInterface.test.ts
@@ -1,4 +1,5 @@
-import { SelectionInterface } from "../simularium";
+import { mapValues } from "lodash";
+import { EncodedTypeMapping, SelectionInterface } from "../simularium";
 
 const idMapping = {
     0: { name: "A" },
@@ -19,7 +20,7 @@ const idMapping = {
 const color = "";
 
 describe("SelectionInterface module", () => {
-    describe("Handles Input", () => {
+    describe("decode", () => {
         test("Can decode valid encoded input", () => {
             const input = "name#tag1_tag2";
             const si = new SelectionInterface();
@@ -47,7 +48,7 @@ describe("SelectionInterface module", () => {
         });
     });
 
-    describe("Parsing", () => {
+    describe("parse", () => {
         test("Parse id-name mapping", () => {
             const si = new SelectionInterface();
             si.parse(idMapping);
@@ -58,6 +59,64 @@ describe("SelectionInterface module", () => {
             expect(si.containsName("D")).toEqual(true);
             expect(si.containsTag("t1")).toEqual(true);
             expect(si.containsTag("t2")).toEqual(true);
+        });
+    });
+
+    describe("getUnmodifiedStateId", () => {
+        test("it returns the id of the unmodified state", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const unmodA = si.getUnmodifiedStateId("A");
+            const unmodB = si.getUnmodifiedStateId("B");
+            const unmodC = si.getUnmodifiedStateId("C");
+            const unmodD = si.getUnmodifiedStateId("D");
+
+            expect(unmodA).toEqual(0);
+            expect(unmodB).toEqual(4);
+            expect(unmodC).toEqual(8);
+            expect(unmodD).toEqual(12);
+        });
+        test("it returns null if no unmodified state", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const unmod = si.getUnmodifiedStateId("E");
+            expect(unmod).toBeNull;
+        });
+    });
+
+    describe("getColorsForName", () => {
+        test("it returns a list of colors for every id an agent name has", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const agentName = "A";
+            const colors = si.getColorsForName(agentName);
+            const ids = si.getIds(agentName);
+            expect(colors.length).toEqual(ids.length);
+        });
+        test("it returns an array of empty strings if no user ids given", () => {
+            const si = new SelectionInterface();
+            si.parse(idMapping);
+            const agentName = "A";
+            const colors = si.getColorsForName(agentName);
+            expect(colors).toEqual(["", "", "", ""]);
+        });
+        test("it returns an array of colors if they are given", () => {
+            const si = new SelectionInterface();
+            const color = "#aaaaa";
+            const idMappingWithColors = mapValues(idMapping, (entry) => {
+                return {
+                    ...entry,
+                    geometry: {
+                        url: "",
+                        displayType: "",
+                        color,
+                    },
+                };
+            });
+            si.parse(idMappingWithColors as EncodedTypeMapping);
+            const agentName = "A";
+            const colors = si.getColorsForName(agentName);
+            expect(colors).toEqual([color, color, color, color]);
         });
     });
 

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -221,57 +221,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                 }
             }
             onTrajectoryFileInfoChanged(trajectoryFileInfo);
-
-            this.visGeometry.clearColorMapping();
-            const uiDisplayData = this.selectionInterface.getUIDisplayData();
-            let defaultColorIndex = 0;
-            let needToUpdateMaterials = false;
-
-            uiDisplayData.forEach((entry) => {
-                // list of ids that all have this same name
-                const ids = this.selectionInterface.getIds(entry.name);
-                const newColors = this.selectionInterface.getColorsForName(entry.name);
-                const hasNewColors = filter(newColors).length > 0
-                if (!hasNewColors) {
-                    // if no colors have been by the user set for this name, 
-                    // just give all states of this agent name the same color
-                    this.visGeometry.setColorForIds(ids, defaultColorIndex)
-                    defaultColorIndex++;
-                    return
-                }
-                newColors.forEach((color, index) => {
-                    let colorIndex = defaultColorIndex
-                    if (color) {
-                        colorIndex = this.colors.indexOf(color)
-                        if (colorIndex == -1) {
-                            // add color to color array
-                            // const colorNum = hexStringToNumber(color)
-                            this.colors = [...this.colors, color];
-                            colorIndex = this.colors.length - 1;
-                        }
-                        needToUpdateMaterials = true
-                    } 
-                    this.visGeometry.setColorForId(
-                        ids[index],
-                        colorIndex
-                    );
-
-                })
-                entry.color =
-                    "#" +
-                    this.visGeometry
-                        .getColorForIndex(defaultColorIndex)
-                        .getHexString();
-                // if we used any of the default color array
-                if (filter(newColors).length !== ids.length) {
-
-                    defaultColorIndex = defaultColorIndex + 1;
-                }
-            });
-            if (needToUpdateMaterials) {
-                this.visGeometry.createMaterials(this.colors)
-            }
-            this.visGeometry.finalizeIdColorMapping();
+            const uiDisplayData = this.setAgentColors();
             onUIDisplayDataChanged(uiDisplayData);
         };
 
@@ -528,6 +478,58 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             }
             this.visGeometry.setFollowObject(NO_AGENT);
         }
+    }
+
+    private setAgentColors() {
+
+        this.visGeometry.clearColorMapping();
+        const uiDisplayData = this.selectionInterface.getUIDisplayData();
+        let defaultColorIndex = 0;
+        let needToUpdateMaterials = false;
+
+        uiDisplayData.forEach((entry) => {
+            // list of ids that all have this same name
+            const ids = this.selectionInterface.getIds(entry.name);
+            const newColors = this.selectionInterface.getColorsForName(
+                entry.name
+            );
+            const hasNewColors = filter(newColors).length > 0;
+            if (!hasNewColors) {
+                // if no colors have been by the user set for this name,
+                // just give all states of this agent name the same color
+                this.visGeometry.setColorForIds(ids, defaultColorIndex);
+                defaultColorIndex++;
+                return;
+            }
+            newColors.forEach((color, index) => {
+                let colorIndex = defaultColorIndex;
+                if (color) {
+                    colorIndex = this.colors.indexOf(color);
+                    if (colorIndex == -1) {
+                        // add color to color array
+                        // const colorNum = hexStringToNumber(color)
+                        this.colors = [...this.colors, color];
+                        colorIndex = this.colors.length - 1;
+                    }
+                    needToUpdateMaterials = true;
+                }
+                this.visGeometry.setColorForId(ids[index], colorIndex);
+            });
+            entry.color =
+                "#" +
+                this.visGeometry
+                    .getColorForIndex(defaultColorIndex)
+                    .getHexString();
+            // if we used any of the default color array
+            if (filter(newColors).length !== ids.length) {
+                defaultColorIndex = defaultColorIndex + 1;
+            }
+        });
+        if (needToUpdateMaterials) {
+            this.visGeometry.createMaterials(this.colors);
+        }
+        this.visGeometry.finalizeIdColorMapping();
+        return uiDisplayData;
     }
 
     private handleTimeChange(e: Event): void {

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -508,9 +508,9 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                 // otherwise, we need to update any user defined colors
                 newColors.forEach((color, index) => {
                     // color for each agent id (can be different states of a single
-                    // entity. Ie, bound and unbound states.
+                    // entity, ie, bound and unbound states).
                     // All agents with unspecified colors in this grouping
-                    // will still get the same color as each other
+                    // will still get the same default color as each other
                     let agentColorIndex = defaultColorIndex;
                     if (color) {
                         agentColorIndex = this.colors.indexOf(color);


### PR DESCRIPTION
Problem
=======
The new simularium file format allows the user to define colors per agent id
Closes #191 

Solution
========
Modify the previous setup to be able to set color per agent id, instead of list of ids. 
I add any user defined colors to the end of the default color array.

If a user defined a color for the "unmodified" state, I use that color for the parent as well. Otherwise the parent (what gets displayed in the checkboxes on the front end) gets a default (random) color. 

## Type of change
Please delete options that are not relevant.
* New feature (non-breaking change which adds functionality)
* This change requires updated or new tests

Steps to Verify:
----------------
1. npm start
2. unzip attached file, drop all the files inside onto the test viewer:
[geo-test-colors.zip](https://github.com/allen-cell-animated/simularium-viewer/files/7290561/geo-test-colors.zip)


Screenshots (optional):
-----------------------
<img width="357" alt="Screen Shot 2021-10-05 at 12 37 26 PM" src="https://user-images.githubusercontent.com/5170636/136133873-ddc7b5f6-53b1-4f10-b5c4-991e135887e9.png">


Keyfiles (delete if not relevant):
-----------------------
1. `setAgentColors` in `src/viewport/index.tsx` does all the work. 
