### PR TITLE
Feature/user colors

### DIFF
--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -1,5 +1,17 @@
+import { filter } from "lodash";
+import { Color } from "three";
+import { VisGeometry } from ".";
 import { EncodedTypeMapping } from "./types";
 
+// interface for testing function without
+// having to mock the whole VisGeometry class
+export interface VisGeometryMock {
+    createMaterials: (colors: (string | number)[]) => void;
+    setColorForIds: () => void;
+    setColorForId: () => void;
+    getColorForIndex: (index: number) => Color;
+    finalizeIdColorMapping: () => void;
+}
 // An individual entry parsed from an encoded name
 interface DecodedTypeEntry {
     id: number;
@@ -24,7 +36,7 @@ interface DisplayStateEntry {
     color: string;
 }
 
-interface UIDisplayEntry {
+export interface UIDisplayEntry {
     name: string;
     displayStates: DisplayStateEntry[];
     color: string;
@@ -233,6 +245,70 @@ class SelectionInterface {
                 color,
             };
         });
+    }
+
+    public setAgentColors(
+        uiDisplayData: UIDisplayData,
+        colors: (string | number)[],
+        visGeometry: VisGeometry | VisGeometryMock
+    ): UIDisplayData {
+        let defaultColorIndex = 0;
+
+        uiDisplayData.forEach((entry) => {
+            // the color for the whole grouping for this entry.name
+            let entryColorIndex = defaultColorIndex;
+            // the id (if present, of the unmodified state of this entry)
+            const unmodifiedId = this.getUnmodifiedStateId(entry.name);
+            // list of ids that all have this same name
+            const ids = this.getIds(entry.name);
+            // list of colors for this entry, will be empty strings for
+            // ids that don't have a user set color
+            const newColors = this.getColorsForName(entry.name);
+            const hasNewColors = filter(newColors).length > 0;
+            if (!hasNewColors) {
+                // if no colors have been set by the user for this name,
+                // just give all states of this agent name the same color
+                visGeometry.setColorForIds(ids, defaultColorIndex);
+            } else {
+                // otherwise, we need to update any user defined colors
+                newColors.forEach((color, index) => {
+                    // color for each agent id (can be different states of a single
+                    // entity, ie, bound and unbound states).
+                    // All agents with unspecified colors in this grouping
+                    // will still get the same default color as each other
+                    let agentColorIndex = defaultColorIndex;
+                    if (color) {
+                        agentColorIndex = colors.indexOf(color);
+                        if (agentColorIndex === -1) {
+                            // add color to color array
+                            colors = [...colors, color];
+                            agentColorIndex = colors.length - 1;
+                            visGeometry.createMaterials(colors);
+                        }
+                    }
+                    // if the user set a color for the unmodified
+                    // state, use that for the whole group as well
+                    // otherwise the grouping color may be completely different
+                    if (unmodifiedId !== null && unmodifiedId === ids[index]) {
+                        entryColorIndex = agentColorIndex;
+                    }
+                    visGeometry.setColorForId(ids[index], agentColorIndex);
+                });
+            }
+            entry.color =
+                "#" +
+                visGeometry.getColorForIndex(entryColorIndex).getHexString();
+
+            // if we used any of the default color array
+            // need to go to the next default color.
+            if (filter(newColors).length !== ids.length) {
+                defaultColorIndex++;
+            }
+        });
+
+        visGeometry.finalizeIdColorMapping();
+        // passed
+        return uiDisplayData;
     }
 }
 

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -1,17 +1,7 @@
 import { filter } from "lodash";
-import { Color } from "three";
 import { VisGeometry } from ".";
 import { EncodedTypeMapping } from "./types";
 
-// interface for testing function without
-// having to mock the whole VisGeometry class
-export interface VisGeometryMock {
-    createMaterials: (colors: (string | number)[]) => void;
-    setColorForIds: () => void;
-    setColorForId: () => void;
-    getColorForIndex: (index: number) => Color;
-    finalizeIdColorMapping: () => void;
-}
 // An individual entry parsed from an encoded name
 interface DecodedTypeEntry {
     id: number;
@@ -250,10 +240,10 @@ class SelectionInterface {
     public setAgentColors(
         uiDisplayData: UIDisplayData,
         colors: (string | number)[],
-        visGeometry: VisGeometry | VisGeometryMock
+        visGeometry: VisGeometry
     ): UIDisplayData {
         let defaultColorIndex = 0;
-
+        let needToUpdateMaterials = false;
         uiDisplayData.forEach((entry) => {
             // the color for the whole grouping for this entry.name
             let entryColorIndex = defaultColorIndex;
@@ -283,7 +273,8 @@ class SelectionInterface {
                             // add color to color array
                             colors = [...colors, color];
                             agentColorIndex = colors.length - 1;
-                            visGeometry.createMaterials(colors);
+                            visGeometry.addNewColor(color);
+                            needToUpdateMaterials = true;
                         }
                     }
                     // if the user set a color for the unmodified
@@ -306,8 +297,7 @@ class SelectionInterface {
             }
         });
 
-        visGeometry.finalizeIdColorMapping();
-        // passed
+        visGeometry.finalizeIdColorMapping(needToUpdateMaterials);
         return uiDisplayData;
     }
 }

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -289,7 +289,7 @@ class SelectionInterface {
                     // if the user set a color for the unmodified
                     // state, use that for the whole group as well
                     // otherwise the grouping color may be completely different
-                    if (unmodifiedId !== null && unmodifiedId === ids[index]) {
+                    if (unmodifiedId === ids[index]) {
                         entryColorIndex = agentColorIndex;
                     }
                     visGeometry.setColorForId(ids[index], agentColorIndex);

--- a/src/simularium/SelectionInterface.ts
+++ b/src/simularium/SelectionInterface.ts
@@ -1,6 +1,6 @@
 import { filter } from "lodash";
-import { VisGeometry } from ".";
 import { EncodedTypeMapping } from "./types";
+import { convertColorNumberToString } from "./VisGeometry/color-utils";
 
 // An individual entry parsed from an encoded name
 interface DecodedTypeEntry {
@@ -240,10 +240,9 @@ class SelectionInterface {
     public setAgentColors(
         uiDisplayData: UIDisplayData,
         colors: (string | number)[],
-        visGeometry: VisGeometry
-    ): UIDisplayData {
+        setColorForIds: (ids: number[], number) => void
+    ): (string | number)[] {
         let defaultColorIndex = 0;
-        let needToUpdateMaterials = false;
         uiDisplayData.forEach((entry) => {
             // the color for the whole grouping for this entry.name
             let entryColorIndex = defaultColorIndex;
@@ -258,7 +257,7 @@ class SelectionInterface {
             if (!hasNewColors) {
                 // if no colors have been set by the user for this name,
                 // just give all states of this agent name the same color
-                visGeometry.setColorForIds(ids, defaultColorIndex);
+                setColorForIds(ids, defaultColorIndex);
             } else {
                 // otherwise, we need to update any user defined colors
                 newColors.forEach((color, index) => {
@@ -273,8 +272,6 @@ class SelectionInterface {
                             // add color to color array
                             colors = [...colors, color];
                             agentColorIndex = colors.length - 1;
-                            visGeometry.addNewColor(color);
-                            needToUpdateMaterials = true;
                         }
                     }
                     // if the user set a color for the unmodified
@@ -283,12 +280,10 @@ class SelectionInterface {
                     if (unmodifiedId === ids[index]) {
                         entryColorIndex = agentColorIndex;
                     }
-                    visGeometry.setColorForId(ids[index], agentColorIndex);
+                    setColorForIds([ids[index]], agentColorIndex);
                 });
             }
-            entry.color =
-                "#" +
-                visGeometry.getColorForIndex(entryColorIndex).getHexString();
+            entry.color = convertColorNumberToString(colors[entryColorIndex]);
 
             // if we used any of the default color array
             // need to go to the next default color.
@@ -297,8 +292,7 @@ class SelectionInterface {
             }
         });
 
-        visGeometry.finalizeIdColorMapping(needToUpdateMaterials);
-        return uiDisplayData;
+        return colors;
     }
 }
 

--- a/src/simularium/VisGeometry/color-utils.ts
+++ b/src/simularium/VisGeometry/color-utils.ts
@@ -1,0 +1,15 @@
+import { Color } from "three";
+
+export function convertColorStringToNumber(color: number | string): number {
+    if (typeof color !== "string") {
+        return color;
+    }
+    return parseInt(color.toString().replace(/^#/, "0x"), 16);
+}
+
+export function convertColorNumberToString(color: number | string): string {
+    if (typeof color === "string") {
+        return color;
+    }
+    return "#" + Color(color).getHexString();
+}

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -77,7 +77,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
     private lastRenderedAgentTime: number;
 
     private stats: Stats;
-    public colors: (number | string)[];
+    public defaultColors: (number | string)[];
     public static defaultProps = {
         renderStyle: RenderStyle.WEBGL2_PREFERRED,
         backgroundColor: [0, 0, 0],
@@ -98,7 +98,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
 
         const loggerLevel =
             props.loggerLevel === "debug" ? jsLogger.DEBUG : jsLogger.OFF;
-        this.colors = props.agentColors || [
+        this.defaultColors = props.agentColors || [
             0x6ac1e5,
             0xff2200,
             0xee7967,
@@ -142,7 +142,7 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         this.visGeometry = new VisGeometry(loggerLevel);
         this.props.simulariumController.visData.clearCache();
         this.visGeometry.setupScene();
-        this.visGeometry.createMaterials(this.colors);
+        this.visGeometry.createMaterials(this.defaultColors);
         this.vdomRef = React.createRef();
         this.lastRenderTime = Date.now();
         this.startTime = Date.now();
@@ -223,10 +223,9 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             onTrajectoryFileInfoChanged(trajectoryFileInfo);
             this.visGeometry.clearColorMapping();
             const uiDisplayData = this.selectionInterface.getUIDisplayData();
-            const updatedColors = this.selectionInterface.setAgentColors(uiDisplayData, this.colors, this.visGeometry.setColorForIds.bind(this.visGeometry));
-            if (!isEqual(updatedColors, this.colors)) {
-                this.colors = updatedColors; 
-                this.visGeometry.createMaterials(this.colors)
+            const updatedColors = this.selectionInterface.setAgentColors(uiDisplayData, this.defaultColors, this.visGeometry.setColorForIds.bind(this.visGeometry));
+            if (!isEqual(updatedColors, this.defaultColors)) {
+                this.visGeometry.createMaterials(updatedColors);
             }
             this.visGeometry.finalizeIdColorMapping();
             onUIDisplayDataChanged(uiDisplayData);

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -485,7 +485,6 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
         this.visGeometry.clearColorMapping();
         const uiDisplayData = this.selectionInterface.getUIDisplayData();
         let defaultColorIndex = 0;
-        let needToUpdateMaterials = false;
 
         uiDisplayData.forEach((entry) => {
             // the color for the whole grouping for this entry.name
@@ -519,12 +518,12 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                             this.colors = [...this.colors, color];
                             agentColorIndex = this.colors.length - 1;
                         }
-                        needToUpdateMaterials = true;
+                        this.visGeometry.createMaterials(this.colors);
                     }
                     // if the user set a color for the unmodified 
                     // state, use that for the whole group as well
                     // otherwise the grouping color may be completely different
-                    if (unmodifiedId && unmodifiedId === ids[index]) {
+                    if (unmodifiedId !== null && unmodifiedId === ids[index]) {
                         entryColorIndex = agentColorIndex;
                     }
                     this.visGeometry.setColorForId(ids[index], agentColorIndex);
@@ -535,16 +534,14 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
                 this.visGeometry
                     .getColorForIndex(entryColorIndex)
                     .getHexString();
-                    
+
             // if we used any of the default color array
             // need to go to the next default color.
             if (filter(newColors).length !== ids.length) {
                 defaultColorIndex++;
             }
         });
-        if (needToUpdateMaterials) {
-            this.visGeometry.createMaterials(this.colors);
-        }
+
         this.visGeometry.finalizeIdColorMapping();
         return uiDisplayData;
     }

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -5,7 +5,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
 import SimulariumController from "../controller";
 
-import { filter, forOwn, isEqual } from "lodash";
+import { forOwn, isEqual } from "lodash";
 
 import {
     VisGeometry,
@@ -223,7 +223,12 @@ class Viewport extends React.Component<ViewportProps, ViewportState> {
             onTrajectoryFileInfoChanged(trajectoryFileInfo);
             this.visGeometry.clearColorMapping();
             const uiDisplayData = this.selectionInterface.getUIDisplayData();
-            this.selectionInterface.setAgentColors(uiDisplayData, this.colors, this.visGeometry);
+            const updatedColors = this.selectionInterface.setAgentColors(uiDisplayData, this.colors, this.visGeometry.setColorForIds.bind(this.visGeometry));
+            if (!isEqual(updatedColors, this.colors)) {
+                this.colors = updatedColors; 
+                this.visGeometry.createMaterials(this.colors)
+            }
+            this.visGeometry.finalizeIdColorMapping();
             onUIDisplayDataChanged(uiDisplayData);
         };
 


### PR DESCRIPTION
Problem
=======
There were two bugs in my implementation of setting user colors that was failing to set the "parent/unmodified" color correctly. 
1. I had a falsey test for a value that could be zero. 
2. I wasn't updating the materials each time I added a new color, so the index into the color array was getting a blank color (white)

Solution
========
I fixed to two issues above, [this commit has those changes clearly](https://github.com/allen-cell-animated/simularium-viewer/pull/204/commits/9d11e08725dabe50525c4e4ebf692efd96f958bc),  but I also wanted to be able to test this function. Since it was in a react component, but didn't really need to be, I moved it to the selection interface (it's all having to do with uiDisplayData so it makes sense there) and wrote some tests. 

They're slightly complex tests because I had to mock the VisGeometry class since it gets called within the function. If you see ways to simplify this or if anything is unclear please let me know. 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
* This change requires updated or new tests

Steps to Verify:
----------------
1. npm start
1. use any of the new v3 files with colors to make sure the colors are getting applied. The parent color issue is only really visible if you install this in the website or through the tests. 

Screenshots (optional):
-----------------------
Here is the bug, the "parent" colors should either be the color of the unmodified state, or one of our default colors, but they are often white because I was indexing past the color array length

<img width="1561" alt="Screen Shot 2021-10-12 at 4 19 55 PM" src="https://user-images.githubusercontent.com/5170636/137194657-fd29f5e2-060a-4c2c-a9e7-b796a8764dc7.png">

