### PR TITLE
add a nightly build script

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,42 @@
+name: github pages
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Cache dependencies
+ 
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+            
+      - run: npm ci
+      - run: npm run gh-build
+      - name: Prepare tag
+        id: prepare_tag
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG_NAME="${GITHUB_REF##refs/tags/}"
+          echo "::set-output name=tag_name::${TAG_NAME}"
+          echo "::set-output name=deploy_tag_name::deploy-${TAG_NAME}"
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          tag_name: ${{ steps.prepare_tag.outputs.deploy_tag_name }}
+          tag_message: 'Deployment to gh-pages to test new viewer ${{ steps.prepare_tag.outputs.tag_name }}'

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "types": "type-declarations",
     "scripts": {
         "start": "webpack serve --config webpack.dev.js",
+        "gh-build": "webpack --config webpack.dev.js",
         "lint": "eslint src/**/*.ts src/**/*.tsx",
         "test": "jest src/**/*.test.ts --coverage",
         "typeCheck": "tsc -p tsconfig.json --noEmit",


### PR DESCRIPTION
Problem
=======
We want to be able to test and use new features without having to have a local build 

Solution
========
Copied over the nightly build script from simularium website, and changed for this setup: change the folder name from dist to public. 

## Type of change
Please delete options that are not relevant.

* New feature (non-breaking change which adds functionality)
