### PR TITLE
fix issue with color varying across same agent

### DIFF
--- a/src/simularium/VisGeometry/rendering/CompositePass.ts
+++ b/src/simularium/VisGeometry/rendering/CompositePass.ts
@@ -148,7 +148,8 @@ class CompositePass {
                     discard;
             
                 // Subtracting 1 because we added 1 before setting this, to account for id 0 being highlighted.
-                int agentColorIndex = int(abs(col0.x)-1.0);
+                // rounding because on some platforms (at least one nvidia+windows) int(abs(...)) is returning values that fluctuate
+                int agentColorIndex = int(round(abs(col0.x))-1.0);
                 // future: can use this value to do other rendering
                 //float highlighted = (sign(col0.x) + 1.0) * 0.5;
 

--- a/src/simularium/VisGeometry/rendering/ContourPass.ts
+++ b/src/simularium/VisGeometry/rendering/ContourPass.ts
@@ -46,6 +46,7 @@ class ContourPass {
               // (TODO: dump buffer after read to inspec?)
               // Straight equality works on MacOS and Intel/Windows gpu 
               // This should be tested periodically with new nvidia drivers on windows
+              // TODO: try "round(abs(x-y)) == 0" here
               return abs(x-y) < 0.1;
             }
             bool isAdjacentToSame(float x, float l, float r, float b, float t) {


### PR DESCRIPTION
Problem
=======
On some platforms the rendering is causing colors to vary across the surface of each agent, as if it is flipping between two different color indices.

![chrome_0dTpn5FmYs](https://user-images.githubusercontent.com/2193409/139759758-51822bec-141b-4480-8c99-f6813dda9137.png)

Solution
========
Add a rounding function when determining agent color index.

## Type of change

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. I'm only aware of repro on Windows+nvidia graphics.

Screenshots (optional):
-----------------------

![chrome_fRq5DScNiy](https://user-images.githubusercontent.com/2193409/139759837-6660ab93-ad07-4a5d-a1d4-a67f20fc20e9.png)
