### PR TITLE
Fix/export FrontEndError

### DIFF
--- a/examples/Viewer.tsx
+++ b/examples/Viewer.tsx
@@ -15,7 +15,7 @@ import { isEqual, findIndex } from "lodash";
 import PointSimulator from "./PointSimulator";
 import PdbSimulator from "./PdbSimulator";
 import CurveSimulator from "./CurveSimulator";
-import FrontEndError from "../src/simularium/FrontEndError";
+import { FrontEndError } from "../src/simularium/FrontEndError";
 
 const netConnectionSettings = {
     serverIp: "staging-node1-agentviz-backend.cellexplore.net",

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -19,7 +19,7 @@ import { ClientSimulator } from "../simularium/ClientSimulator";
 import { IClientSimulatorImpl } from "../simularium/localSimulators/IClientSimulatorImpl";
 import { ISimulator } from "../simularium/ISimulator";
 import { LocalFileSimulator } from "../simularium/LocalFileSimulator";
-import FrontEndError from "../simularium/FrontEndError";
+import { FrontEndError } from "../simularium/FrontEndError";
 
 jsLogger.setHandler(jsLogger.createDefaultHandler());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
     RemoteSimulator,
     DummyRemoteSimulator,
     ErrorLevel,
+    FrontEndError,
 } from "./simularium";
 export { compareTimes } from "./util";
 

--- a/src/simularium/FrontEndError.ts
+++ b/src/simularium/FrontEndError.ts
@@ -4,7 +4,7 @@ export enum ErrorLevel {
     WARNING = "warning",
 }
 
-class FrontEndError extends Error {
+export class FrontEndError extends Error {
     public htmlData: string;
     public level: ErrorLevel;
     constructor(
@@ -21,5 +21,3 @@ class FrontEndError extends Error {
         this.level = level;
     }
 }
-
-export default FrontEndError;

--- a/src/simularium/LocalFileSimulator.ts
+++ b/src/simularium/LocalFileSimulator.ts
@@ -10,7 +10,7 @@ import {
     SimulariumFileFormat,
 } from "./types";
 import { ISimulator } from "./ISimulator";
-import FrontEndError from "./FrontEndError";
+import { FrontEndError } from "./FrontEndError";
 
 // a LocalFileSimulator is a ISimulator that plays back the contents of
 // a drag-n-drop trajectory file (a SimulariumFileFormat object)

--- a/src/simularium/RemoteSimulator.ts
+++ b/src/simularium/RemoteSimulator.ts
@@ -1,6 +1,6 @@
 import jsLogger from "js-logger";
 import { ILogger } from "js-logger";
-import FrontEndError, { ErrorLevel } from "./FrontEndError";
+import { FrontEndError, ErrorLevel } from "./FrontEndError";
 
 import { ISimulator } from "./ISimulator";
 import { TrajectoryFileInfoV2, VisDataMessage } from "./types";

--- a/src/simularium/VisData.ts
+++ b/src/simularium/VisData.ts
@@ -8,7 +8,7 @@ import {
     EncodedTypeMapping,
     VisDataMessage,
 } from "./types";
-import FrontEndError, { ErrorLevel } from "./FrontEndError";
+import { FrontEndError, ErrorLevel } from "./FrontEndError";
 
 /**
  * Parse Agents from Net Data

--- a/src/simularium/VisGeometry/index.ts
+++ b/src/simularium/VisGeometry/index.ts
@@ -32,7 +32,7 @@ import { cloneDeep, noop } from "lodash";
 import VisAgent from "./VisAgent";
 import VisTypes from "../VisTypes";
 import PDBModel from "./PDBModel";
-import FrontEndError, { ErrorLevel } from "../FrontEndError";
+import { FrontEndError, ErrorLevel } from "../FrontEndError";
 
 import {
     DEFAULT_CAMERA_Z_POSITION,

--- a/src/simularium/index.tsx
+++ b/src/simularium/index.tsx
@@ -13,8 +13,8 @@ export type {
     UIDisplayData
 } from "./SelectionInterface";
 export {
-    ErrorLevel
-} from "./FrontEndError"
+    ErrorLevel, FrontEndError
+} from "./FrontEndError";
 export {
     RemoteSimulator,
     NetMessageEnum

--- a/src/simularium/versionHandlers.ts
+++ b/src/simularium/versionHandlers.ts
@@ -2,7 +2,7 @@ import { mapValues } from "lodash";
 import * as si from "si-prefix";
 
 import { DEFAULT_CAMERA_SPEC } from "../constants";
-import FrontEndError, { ErrorLevel } from "./FrontEndError";
+import { FrontEndError, ErrorLevel } from "./FrontEndError";
 import {
     AgentDisplayDataWithGeometry,
     TrajectoryFileInfo,

--- a/src/test/FrontEndError.test.ts
+++ b/src/test/FrontEndError.test.ts
@@ -1,4 +1,4 @@
-import FrontEndError, { ErrorLevel } from "../simularium/FrontEndError";
+import { FrontEndError, ErrorLevel } from "../simularium/FrontEndError";
 
 describe("FrontEndError", () => {
     test("it creates an error object with a message", () => {

--- a/src/test/RemoteSimulator.test.ts
+++ b/src/test/RemoteSimulator.test.ts
@@ -2,7 +2,7 @@ import {
     CONNECTION_SUCCESS_MSG,
     CONNECTION_FAIL_MSG,
 } from "../simularium/RemoteSimulator";
-import FrontEndError from "../simularium/FrontEndError";
+import { FrontEndError } from "../simularium/FrontEndError";
 import { RemoteSimulator } from "..";
 
 describe("RemoteSimulator", () => {

--- a/src/test/versionHandlers.test.ts
+++ b/src/test/versionHandlers.test.ts
@@ -1,4 +1,4 @@
-import FrontEndError from "../simularium/FrontEndError";
+import { FrontEndError } from "../simularium/FrontEndError";
 import {
     makeMissingDisplayTypeErrorMessage,
     makeMissingUrlErrorMessage,

--- a/src/viewport/index.tsx
+++ b/src/viewport/index.tsx
@@ -18,7 +18,7 @@ import {
 import { TrajectoryFileInfoAny } from "../simularium/types";
 import { RenderStyle } from "../simularium";
 import { updateTrajectoryFileInfoFormat } from "../simularium/versionHandlers";
-import FrontEndError, { ErrorLevel } from "../simularium/FrontEndError";
+import { FrontEndError, ErrorLevel } from "../simularium/FrontEndError";
 
 export type PropColor = string | number | [number, number, number];
 


### PR DESCRIPTION
Problem
=======
The class `FrontEndError` is not exported, but we need it in simularium-website. It looks like we've been using [this incomplete duplicate](https://github.com/allen-cell-animated/simularium-website/blob/0c13df0e56eb416d68012c79ce9905a4091c3c39/src/state/viewer/types.ts#L43) in simularium-website so far, but we should just import the real thing from simularium-viewer.

Solution
========
* Export `FrontEndError` out of this application
* While doing the above I also changed `FrontEndError.ts` from using a default export for `FrontEndError` to using a named export. I think making this a named export is safer (less likely to import the wrong thing).

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Keyfiles (delete if not relevant):
-----------------------
1. src/simularium/index.tsx - export `FrontEndError` out of this app

Everything else is changing `import FrontEndError` to `import { FrontEndError }`
