### PR TITLE
Fix/use "new" to construct a new instance of Color

### DIFF
--- a/src/simularium/VisGeometry/color-utils.ts
+++ b/src/simularium/VisGeometry/color-utils.ts
@@ -11,5 +11,5 @@ export function convertColorNumberToString(color: number | string): string {
     if (typeof color === "string") {
         return color;
     }
-    return "#" + Color(color).getHexString();
+    return "#" + new Color(color).getHexString();
 }

--- a/src/test/color-utils.test.ts
+++ b/src/test/color-utils.test.ts
@@ -1,0 +1,23 @@
+import {
+    convertColorStringToNumber,
+    convertColorNumberToString,
+} from "../simularium/VisGeometry/color-utils";
+
+describe("VisGeometry color-utils", () => {
+    describe("convertColorStringToNumber", () => {
+        test("returns a color number as is", () => {
+            expect(convertColorStringToNumber(16777215)).toEqual(16777215);
+        });
+        test("converts a color string to a base-16 number", () => {
+            expect(convertColorStringToNumber("#ffffff")).toEqual(16777215);
+        });
+    });
+    describe("convertColorNumberToString", () => {
+        test("returns a color string as is", () => {
+            expect(convertColorNumberToString("#ffffff")).toEqual("#ffffff");
+        });
+        test("converts a color string to a base-16 number", () => {
+            expect(convertColorNumberToString(16777215)).toEqual("#ffffff");
+        });
+    });
+});

--- a/src/test/color-utils.test.ts
+++ b/src/test/color-utils.test.ts
@@ -8,7 +8,7 @@ describe("VisGeometry color-utils", () => {
         test("returns a color number as is", () => {
             expect(convertColorStringToNumber(16777215)).toEqual(16777215);
         });
-        test("converts a color string to a base-16 number", () => {
+        test("converts a hex color string to a base-16 number", () => {
             expect(convertColorStringToNumber("#ffffff")).toEqual(16777215);
         });
     });
@@ -16,7 +16,7 @@ describe("VisGeometry color-utils", () => {
         test("returns a color string as is", () => {
             expect(convertColorNumberToString("#ffffff")).toEqual("#ffffff");
         });
-        test("converts a color string to a base-16 number", () => {
+        test("converts a base-16 color number to a hex color string", () => {
             expect(convertColorNumberToString(16777215)).toEqual("#ffffff");
         });
     });


### PR DESCRIPTION
Problem
=======
Closes #226 

Solution
========
* I did a global search for `Color(` and added a `new` in front of the one instance that was missing it, in color-utils.ts.
* Added tests for color-utils.

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

Steps to Verify:
----------------
1. On main branch, `npm start`
2. Drag-and-drop the PhysiCell file mentioned in the issue (https://aics-simularium-data.s3.us-east-2.amazonaws.com/trajectory/physicell_test.simularium). It should not load successfully, and an error message about needing `new` should show in the console
3. Switch to this branch
4. Drag and drop the same file again. It should load successfully this time.
